### PR TITLE
Removes a warning. Ref #4

### DIFF
--- a/internal/util-collection/src/main/scala/sbt/INode.scala
+++ b/internal/util-collection/src/main/scala/sbt/INode.scala
@@ -27,7 +27,6 @@ abstract class EvaluateSettings[Scope] {
       case k: Keyed[s, T] @unchecked          => single(getStatic(k.scopedKey), k.transform)
       case a: Apply[k, T] @unchecked          => new MixedNode[k, T](a.alist.transform[Initialize, INode](a.inputs, transform), a.f, a.alist)
       case b: Bind[s, T] @unchecked           => new BindNode[s, T](transform(b.in), x => transform(b.f(x)))
-      case init.StaticScopes                  => strictConstant(allScopes.asInstanceOf[T]) // can't convince scalac that StaticScopes => T == Set[Scope]
       case v: Value[T] @unchecked             => constant(v.value)
       case v: ValidationCapture[T] @unchecked => strictConstant(v.key)
       case t: TransformCapture                => strictConstant(t.f)
@@ -35,6 +34,7 @@ abstract class EvaluateSettings[Scope] {
         case None    => constant(() => o.f(None))
         case Some(i) => single[s, T](transform(i), x => o.f(Some(x)))
       }
+      case x if x == StaticScopes => strictConstant(allScopes.asInstanceOf[T]) // can't convince scalac that StaticScopes => T == Set[Scope]
     }
   }
   private[this] lazy val roots: Seq[INode[_]] = compiledSettings flatMap { cs =>


### PR DESCRIPTION
Exhaustion check was not picking up StaticScopes, which is an object.

/review @Duhemm, @dwijnand 
