### PR TITLE
Make `sbt.internal.util.JLine` private to sbt package

### DIFF
--- a/internal/util-complete/src/main/scala/sbt/internal/util/LineReader.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/LineReader.scala
@@ -58,7 +58,7 @@ abstract class JLine extends LineReader {
     reader.flush()
   }
 }
-private object JLine {
+private[sbt] object JLine {
   private[this] val TerminalProperty = "jline.terminal"
 
   fixTerminalProperty()


### PR DESCRIPTION
It was private to `sbt.internal.util`, but it is used in sbt's codebase.
