### PR TITLE
Fixes sbt/util#20

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import Dependencies._
 import Util._
 
-def baseVersion: String = "0.1.0-M5"
+def baseVersion: String = "0.1.0-M6"
 def internalPath   = file("internal")
 
 def commonSettings: Seq[Setting[_]] = Seq(

--- a/project/Util.scala
+++ b/project/Util.scala
@@ -10,7 +10,8 @@ object Util {
     crossPaths := false,
     compileOrder := CompileOrder.JavaThenScala,
     unmanagedSourceDirectories in Compile <<= Seq(javaSource in Compile).join,
-    crossScalaVersions := Seq(Dependencies.scala211)
+    crossScalaVersions := Seq(Dependencies.scala211),
+    autoScalaLibrary := false
   )
 
   def getScalaKeywords: Set[String] =


### PR DESCRIPTION
Fixes sbt/util#20 by removing scala-library dependencies from the Java-only util-interface.
I've tagged this 0.1.0-M6 and it's released.

/review @Duhemm, @dwijnand
