### PR TITLE
Don't inject thread sleep by default

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import Dependencies._
 import Util._
 import com.typesafe.tools.mima.core._, ProblemFilters._
 
-def baseVersion: String = "0.1.0-M9"
+def baseVersion: String = "0.1.0-M10"
 def internalPath   = file("internal")
 
 def commonSettings: Seq[Setting[_]] = Seq(

--- a/internal/util-complete/src/main/scala/sbt/internal/util/LineReader.scala
+++ b/internal/util-complete/src/main/scala/sbt/internal/util/LineReader.scala
@@ -124,7 +124,7 @@ private[sbt] object JLine {
   def simple(
     historyPath: Option[File],
     handleCONT: Boolean = HandleCONT,
-    injectThreadSleep: Boolean = true
+    injectThreadSleep: Boolean = false
   ): SimpleReader = new SimpleReader(historyPath, handleCONT, injectThreadSleep)
   val MaxHistorySize = 500
   val HandleCONT = !java.lang.Boolean.getBoolean("sbt.disable.cont") && Signals.supported(Signals.CONT)
@@ -147,7 +147,7 @@ final class FullReader(
   historyPath: Option[File],
   complete: Parser[_],
   val handleCONT: Boolean = JLine.HandleCONT,
-  val injectThreadSleep: Boolean = true
+  val injectThreadSleep: Boolean = false
 ) extends JLine {
   protected[this] val reader =
     {
@@ -160,5 +160,5 @@ final class FullReader(
 class SimpleReader private[sbt] (historyPath: Option[File], val handleCONT: Boolean, val injectThreadSleep: Boolean) extends JLine {
   protected[this] val reader = JLine.createReader(historyPath, injectThreadSleep)
 }
-object SimpleReader extends SimpleReader(None, JLine.HandleCONT, true)
+object SimpleReader extends SimpleReader(None, JLine.HandleCONT, false)
 


### PR DESCRIPTION
Fixes #32 

Thread sleeping interferes with scripted test when the build cannot be
loaded. The scripted test gets stuck, and jstack shows

```
    java.lang.Thread.State: TIMED_WAITING (sleeping)
      at java.lang.Thread.sleep(Native Method)
      at sbt.internal.util.InputStreamWrapper.read(LineReader.scala:138)
      at
jline.internal.NonBlockingInputStream.read(NonBlockingInputStream.java:2
45)
      ....
      at sbt.internal.util.JLine$.withJLine(LineReader.scala:118)
      at sbt.internal.util.JLine.readLine(LineReader.scala:18)
      at
sbt.BuiltinCommands$.sbt$BuiltinCommands$$doLoadFailed(Main.scala:460)
```

/review @dwijnand @Duhemm 
