### PR TITLE
2.12 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,6 @@ scala: 2.11.8
 
 script:
   - sbt -Dfile.encoding=UTF8 -J-XX:ReservedCodeCacheSize=256M "so test"
+
+jdk:
+  - oraclejdk8

--- a/build.sbt
+++ b/build.sbt
@@ -6,17 +6,22 @@ def baseVersion: String = "0.1.0-M15"
 def internalPath   = file("internal")
 
 def commonSettings: Seq[Setting[_]] = Seq(
-  scalaVersion := scala211,
+  scalaVersion := scala212,
   // publishArtifact in packageDoc := false,
   resolvers += Resolver.typesafeIvyRepo("releases"),
   resolvers += Resolver.sonatypeRepo("snapshots"),
   // concurrentRestrictions in Global += Util.testExclusiveRestriction,
   testOptions += Tests.Argument(TestFrameworks.ScalaCheck, "-w", "1"),
   javacOptions in compile ++= Seq("-target", "6", "-source", "6", "-Xlint", "-Xlint:-serial"),
-  crossScalaVersions := Seq(scala211),
+  crossScalaVersions := Seq(scala211, scala212),
   scalacOptions ++= Seq("-Ywarn-unused", "-Ywarn-unused-import"),
-  scalacOptions --= // scalac 2.10 rejects some HK types under -Xfuture it seems..
-    (CrossVersion partialVersion scalaVersion.value collect { case (2, 10) => List("-Xfuture", "-Ywarn-unused", "-Ywarn-unused-import") }).toList.flatten,
+  scalacOptions --=
+    (CrossVersion partialVersion scalaVersion.value collect {
+      // scalac 2.10 rejects some HK types under -Xfuture it seems..
+      case (2, 10) => List("-Xfuture", "-Ywarn-unused", "-Ywarn-unused-import")
+      // -Yinline-warnings no longer exists in 2.12
+      case (2, 12) => List("-Yinline-warnings")
+  }).toList.flatten,
   scalacOptions in console in Compile -= "-Ywarn-unused-import",
   scalacOptions in console in Test    -= "-Ywarn-unused-import",
   previousArtifact := None, // Some(organization.value %% moduleName.value % "1.0.0"),
@@ -153,7 +158,7 @@ lazy val utilScripted = (project in internalPath / "util-scripted").
     commonSettings,
     name := "Util Scripted",
     libraryDependencies ++= {
-      if (scalaVersion.value startsWith "2.11") Seq(parserCombinator211)
+      if (scalaVersion.value.startsWith("2.11") || scalaVersion.value.startsWith("2.12")) Seq(parserCombinator)
       else Seq()
     }
   ).

--- a/internal/util-collection/src/main/scala/sbt/internal/util/IDSet.scala
+++ b/internal/util-collection/src/main/scala/sbt/internal/util/IDSet.scala
@@ -36,7 +36,10 @@ object IDSet {
     def +=(t: T) = { backing.put(t, Dummy); () }
     def ++=(t: Iterable[T]) = t foreach +=
     def -=(t: T) = if (backing.remove(t) eq null) false else true
-    def all = collection.JavaConversions.collectionAsScalaIterable(backing.keySet)
+    def all = {
+      import collection.JavaConverters._
+      backing.keySet.asScala
+    }
     def toList = all.toList
     def isEmpty = backing.isEmpty
     def process[S](t: T)(ifSeen: S)(ifNew: => S) = if (contains(t)) ifSeen else { this += t; ifNew }

--- a/internal/util-collection/src/main/scala/sbt/util/Eval.scala
+++ b/internal/util-collection/src/main/scala/sbt/util/Eval.scala
@@ -47,8 +47,8 @@ sealed abstract class Eval[A] extends Serializable { self =>
       case c: Eval.Compute[A] =>
         new Eval.Compute[B] {
           type Start = c.Start
-          val start = c.start
-          val run = (s: c.Start) =>
+          val start: () => Eval[Start] = c.start
+          val run: Start => Eval.Compute[B] = (s: c.Start) =>
             new Eval.Compute[B] {
               type Start = A
               val start = () => c.run(s)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -31,8 +31,8 @@ object Dependencies {
   val scalaCompiler = Def.setting { "org.scala-lang" % "scala-compiler" % scalaVersion.value }
   val scalaReflect = Def.setting { "org.scala-lang" % "scala-reflect" % scalaVersion.value }
 
-  val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.13.1"
-  val scalatest = "org.scalatest" %% "scalatest" % "2.2.6"
+  val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.13.4"
+  val scalatest = "org.scalatest" %% "scalatest" % "3.0.1"
 
   val parserCombinator211 = "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -34,7 +34,7 @@ object Dependencies {
   val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.13.4"
   val scalatest = "org.scalatest" %% "scalatest" % "3.0.1"
 
-  val parserCombinator211 = "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4"
+  val parserCombinator = "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4"
 
   val sjsonnewVersion = "0.5.1"
   val sjsonnew = "com.eed3si9n" %% "sjson-new-core" % sjsonnewVersion


### PR DESCRIPTION
See commit messages.

There are a few new warnings shown. Nothing dramatic but I can look to fix them if you want:
```
[warn] /home/antoras/workspace/util/internal/util-complete/src/main/scala/sbt/internal/util/complete/Parser.scala:292: private method in <$anon: sbt.internal.util.complete.RichParser[A]> is never used
[warn]     def unary_- = not(a, "Unexpected: " + a)
[warn]         ^
[warn] /home/antoras/workspace/util/internal/util-complete/src/main/scala/sbt/internal/util/complete/Parser.scala:294: private method in <$anon: sbt.internal.util.complete.RichParser[A]> is never used
[warn]     def -(o: Parser[_]) = and(a, not(o, "Unexpected: " + o))
[warn]         ^
[warn] /home/antoras/workspace/util/internal/util-appmacro/src/main/scala/sbt/internal/util/appmacro/Instance.scala:58: Variable x undefined in comment for method contImpl in object Instance
[warn]    * The original wrapped expression `wrap(input)` is replaced by a reference to a new local `val $x: T`, where `$x` is a fresh name.
[warn]                                                                                                    ^
[warn] /home/antoras/workspace/util/internal/util-appmacro/src/main/scala/sbt/internal/util/appmacro/Instance.scala:58: Variable x undefined in comment for method contImpl in object Instance
[warn]    * The original wrapped expression `wrap(input)` is replaced by a reference to a new local `val $x: T`, where `$x` is a fresh name.
[warn]                                                                                                                   ^
[warn] /home/antoras/workspace/util/internal/util-complete/src/main/scala/sbt/internal/util/complete/ExampleSource.scala:7: Could not find any member to link for "sbt.complete.FileExamples".
[warn] /**
[warn] ^
[warn] two warnings found
```