### PR TITLE
Handle ReusableObjectMessage

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,11 +2,11 @@ import Dependencies._
 import Util._
 import com.typesafe.tools.mima.core._, ProblemFilters._
 
-def baseVersion: String = "1.0.0-M18"
+def baseVersion: String = "1.0.0-M19"
 def internalPath   = file("internal")
 
 def commonSettings: Seq[Setting[_]] = Seq(
-  scalaVersion := scala211,
+  scalaVersion := scala212,
   // publishArtifact in packageDoc := false,
   resolvers += Resolver.typesafeIvyRepo("releases"),
   resolvers += Resolver.sonatypeRepo("snapshots"),

--- a/internal/util-logging/src/main/scala/sbt/internal/util/ConsoleAppender.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/ConsoleAppender.scala
@@ -5,7 +5,7 @@ import java.io.{ PrintStream, PrintWriter }
 import java.util.Locale
 import java.util.concurrent.atomic.AtomicInteger
 import org.apache.logging.log4j.{ Level => XLevel }
-import org.apache.logging.log4j.message.{ Message, ParameterizedMessage, ObjectMessage }
+import org.apache.logging.log4j.message.{ Message, ParameterizedMessage, ObjectMessage, ReusableObjectMessage }
 import org.apache.logging.log4j.core.{ LogEvent => XLogEvent }
 import org.apache.logging.log4j.core.appender.AbstractAppender
 import org.apache.logging.log4j.core.layout.PatternLayout
@@ -244,10 +244,11 @@ class ConsoleAppender private[ConsoleAppender] (
 
   def messageToString(msg: Message): String =
     msg match {
-      case p: ParameterizedMessage => p.getFormattedMessage
-      case r: RingBufferLogEvent   => r.getFormattedMessage
-      case o: ObjectMessage        => objectToString(o.getParameter)
-      case _                       => msg.toString
+      case p: ParameterizedMessage  => p.getFormattedMessage
+      case r: RingBufferLogEvent    => r.getFormattedMessage
+      case o: ObjectMessage         => objectToString(o.getParameter)
+      case o: ReusableObjectMessage => objectToString(o.getParameter)
+      case _                        => msg.getFormattedMessage
     }
   def objectToString(o: AnyRef): String =
     o match {


### PR DESCRIPTION
When log4j2 is not using async logging, it sends the ObjectMessage using ReusableObjectMessage.

before:

```
> show bgList
[info] *  (out-53)
[info] org.apache.logging.log4j.core.impl.MutableLogEvent@6d7005e2 (out-53)
```

after:

```
> show bgList
[info] * JobHandle(2,bgRun,{file:/xxx/servertestbuild/}testServer/compile:bgRun) (out-75)
[info] Total time: 0 s, completed Jan 18, 2017 6:45:43 AM (out-75)
```
