### PR TITLE
Fixes buffered log appender

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import Dependencies._
 import Util._
 import com.typesafe.tools.mima.core._, ProblemFilters._
 
-def baseVersion: String = "1.0.0-M21"
+def baseVersion: String = "1.0.0-M24"
 def internalPath   = file("internal")
 
 def commonSettings: Seq[Setting[_]] = Seq(

--- a/internal/util-logging/src/main/scala/sbt/internal/util/BufferedLogger.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/BufferedLogger.scala
@@ -38,7 +38,7 @@ class BufferedAppender private[BufferedAppender] (name: String, delegate: Append
   def append(event: XLogEvent): Unit =
     {
       if (recording) {
-        buffer += event
+        buffer += event.toImmutable
       } else delegate.append(event)
     }
 

--- a/internal/util-logging/src/main/scala/sbt/internal/util/ObjectEvent.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/ObjectEvent.scala
@@ -15,6 +15,8 @@ final class ObjectEvent[A](
   val contentType: String,
   val json: JValue
 ) extends Serializable {
+  override def toString: String =
+    s"ObjectEvent($level, $message, $channelName, $execId, $contentType, $json)"
 }
 
 object ObjectEvent {


### PR DESCRIPTION
Ref sbt/sbt#3198

This fixes the buffered log not showing up for tests by converting log4j's RingBufferLogEvent to an immutable one.
