### PR TITLE
Bump to using sbt 1.0.0-M6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: scala
 
 scala:
-  - 2.11.8
-  - 2.12.1
+  - 2.11.11
+  - 2.12.2
 
 script:
-  - sbt -Dfile.encoding=UTF8 -J-XX:ReservedCodeCacheSize=256M "plz $TRAVIS_SCALA_VERSION test"
+  - sbt -Dfile.encoding=UTF8 -J-XX:ReservedCodeCacheSize=256M "++$TRAVIS_SCALA_VERSION" test
 
 jdk:
   - oraclejdk8

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import Dependencies._
 import Util._
-import com.typesafe.tools.mima.core._, ProblemFilters._
+// import com.typesafe.tools.mima.core._, ProblemFilters._
 
 def baseVersion: String = "1.0.0-M24"
 def internalPath   = file("internal")
@@ -19,12 +19,13 @@ def commonSettings: Seq[Setting[_]] = Seq(
     val old = scalacOptions.value
     scalaVersion.value match {
       case sv if sv.startsWith("2.10") => old diff List("-Xfuture", "-Ywarn-unused", "-Ywarn-unused-import")
-      case _                           => old ++ List("-Ywarn-unused", "-Ywarn-unused-import")
+      case sv if sv.startsWith("2.11") => old ++ List("-Ywarn-unused", "-Ywarn-unused-import")
+      case _                           => old ++ List("-Ywarn-unused", "-Ywarn-unused-import", "-YdisableFlatCpCaching")
     }
   },
   scalacOptions in console in Compile -= "-Ywarn-unused-import",
   scalacOptions in console in Test    -= "-Ywarn-unused-import",
-  mimaPreviousArtifacts := Set(), // Some(organization.value %% moduleName.value % "1.0.0"),
+  // mimaPreviousArtifacts := Set(), // Some(organization.value %% moduleName.value % "1.0.0"),
   publishArtifact in Compile := true,
   publishArtifact in Test := false
 )
@@ -156,7 +157,7 @@ lazy val utilTesting = (project in internalPath / "util-testing").
   configure(addSbtIO)
 
 lazy val utilScripted = (project in internalPath / "util-scripted").
-  dependsOn(utilLogging).
+  dependsOn(utilLogging, utilInterface).
   settings(
     commonSettings,
     name := "Util Scripted",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,8 +3,8 @@ import Keys._
 
 object Dependencies {
   val scala210 = "2.10.6"
-  val scala211 = "2.11.8"
-  val scala212 = "2.12.1"
+  val scala211 = "2.11.11"
+  val scala212 = "2.12.2"
 
   private val ioVersion = "1.0.0-M10"
 
@@ -20,10 +20,16 @@ object Dependencies {
 
   lazy val sbtIoPath = getSbtModulePath("sbtio.path", "sbt/io")
 
-  def addSbtModule(p: Project, path: Option[String], projectName: String, m: ModuleID, c: Option[Configuration] = None) =
+  def addSbtModule(p: Project,
+                   path: Option[String],
+                   projectName: String,
+                   m: ModuleID,
+                   c: Option[Configuration] = None) =
     path match {
-      case Some(f) => p dependsOn c.fold[ClasspathDependency](ProjectRef(file(f), projectName))(ProjectRef(file(f), projectName) % _)
-      case None    => p settings (libraryDependencies += c.fold(m)(m % _))
+      case Some(f) =>
+        p dependsOn c.fold[ClasspathDep[ProjectReference]](ProjectRef(file(f), projectName))(
+          ProjectRef(file(f), projectName) % _)
+      case None => p settings (libraryDependencies += c.fold(m)(m % _))
     }
 
   def addSbtIO(p: Project): Project = addSbtModule(p, sbtIoPath, "io", sbtIO)

--- a/project/bintray.sbt
+++ b/project/bintray.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=1.0.0-M6

--- a/project/contraband.sbt
+++ b/project/contraband.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("org.scala-sbt" % "sbt-contraband" % "0.3.0-M4")

--- a/project/doge.sbt
+++ b/project/doge.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("com.eed3si9n" % "sbt-doge" % "0.1.5")

--- a/project/house.sbt
+++ b/project/house.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("org.scala-sbt" % "sbt-houserules" % "0.3.2")

--- a/project/pgp.sbt
+++ b/project/pgp.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,4 @@
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.4.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0-M1")
+addSbtPlugin("org.scala-sbt" % "sbt-houserules" % "0.3.3")
+addSbtPlugin("org.scala-sbt" % "sbt-contraband" % "0.3.0-M5")


### PR DESCRIPTION
## notes

I saw some weird Java compilation errors:

```
[error] /xxx/util/internal/util-scripted/src/main/java/sbt/internal/scripted/ScriptConfig.java:5:1: package xsbti does not exist
[error] import xsbti.Logger;
[error] /xxx/util/internal/util-scripted/src/main/java/sbt/internal/scripted/ScriptConfig.java:11:1: cannot find symbol
[error]   symbol:   class Logger
[error]   location: class sbt.internal.scripted.ScriptConfig
[error] 	private Logger logger;
[error] /xxx/util/internal/util-scripted/src/main/java/sbt/internal/scripted/ScriptConfig.java:13:1: cannot find symbol
[error]   symbol:   class Logger
[error]   location: class sbt.internal.scripted.ScriptConfig
[error] 	public ScriptConfig(String label, File testDirectory, Logger logger) {
[error] ## Exception when compiling 9 sources to /xxx/util/internal/util-scripted/target/scala-2.12/classes
```

I think it went away when I downgraded to 2.12.1, so I added `"-YdisableFlatCpCaching"`.

https://github.com/scala/bug/issues/10295?