### PR TITLE
Fix casting error during initialization

### DIFF
--- a/internal/util-logging/src/main/scala/sbt/internal/util/ConsoleAppender.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/ConsoleAppender.scala
@@ -8,7 +8,6 @@ import org.apache.logging.log4j.{ Level => XLevel }
 import org.apache.logging.log4j.message.{ Message, ObjectMessage, ReusableObjectMessage }
 import org.apache.logging.log4j.core.{ LogEvent => XLogEvent }
 import org.apache.logging.log4j.core.appender.AbstractAppender
-import org.apache.logging.log4j.core.layout.PatternLayout
 
 import ConsoleAppender._
 
@@ -242,7 +241,7 @@ class ConsoleAppender private[ConsoleAppender] (
   val ansiCodesSupported: Boolean,
   val useColor: Boolean,
   val suppressedMessage: SuppressedTraceContext => Option[String]
-) extends AbstractAppender(name, null, PatternLayout.createDefaultLayout(), true) {
+) extends AbstractAppender(name, null, LogExchange.dummyLayout, true) {
   import scala.Console.{ BLUE, GREEN, RED, RESET, YELLOW }
 
   def append(event: XLogEvent): Unit =


### PR DESCRIPTION
While running scripted, you see

```
ERROR StatusLogger Unable to create custom ContextSelector. Falling back to default.
 java.lang.ClassCastException: Cannot cast org.apache.logging.log4j.core.async.AsyncLoggerContextSelector to org.apache.logging.log4j.core.selector.ContextSelector
	at java.lang.Class.cast(Class.java:3369)
	at org.apache.logging.log4j.util.LoaderUtil.newCheckedInstanceOf(LoaderUtil.java:201)
	at org.apache.logging.log4j.util.LoaderUtil.newCheckedInstanceOfProperty(LoaderUtil.java:226)
	at org.apache.logging.log4j.core.impl.Log4jContextFactory.createContextSelector(Log4jContextFactory.java:97)
	at org.apache.logging.log4j.core.impl.Log4jContextFactory.<init>(Log4jContextFactory.java:58)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at java.lang.Class.newInstance(Class.java:442)
	at org.apache.logging.log4j.LogManager.<clinit>(LogManager.java:94)
	at org.apache.logging.log4j.spi.ThreadContextMapFactory.createThreadContextMap(ThreadContextMapFactory.java:73)
	at org.apache.logging.log4j.ThreadContext.init(ThreadContext.java:223)
	at org.apache.logging.log4j.ThreadContext.<clinit>(ThreadContext.java:202)
	at org.apache.logging.log4j.core.impl.ContextDataInjectorFactory.createDefaultInjector(ContextDataInjectorFactory.java:83)
	at org.apache.logging.log4j.core.impl.ContextDataInjectorFactory.createInjector(ContextDataInjectorFactory.java:67)
	at org.apache.logging.log4j.core.lookup.ContextMapLookup.<init>(ContextMapLookup.java:34)
	at org.apache.logging.log4j.core.lookup.Interpolator.<init>(Interpolator.java:117)
	at org.apache.logging.log4j.core.config.AbstractConfiguration.<init>(AbstractConfiguration.java:125)
	at org.apache.logging.log4j.core.config.DefaultConfiguration.<init>(DefaultConfiguration.java:46)
	at org.apache.logging.log4j.core.layout.PatternLayout$Builder.build(PatternLayout.java:650)
	at org.apache.logging.log4j.core.layout.PatternLayout.createDefaultLayout(PatternLayout.java:487)
	at sbt.internal.util.ConsoleAppender.<init>(ConsoleAppender.scala:245)
```

This aims to workaround the error.