### PR TITLE
Filter out color in CosoleAppender only

### DIFF
--- a/internal/util-logging/src/main/scala/sbt/internal/util/BufferedLogger.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/BufferedLogger.scala
@@ -116,7 +116,9 @@ class BufferedLogger(delegate: AbstractLogger) extends BasicLogger {
   /** Plays buffered events and disables buffering. */
   def stop(): Unit = synchronized { play(); clear() }
 
+  @deprecated("No longer used.", "1.0.0")
   override def ansiCodesSupported = delegate.ansiCodesSupported
+
   override def setLevel(newLevel: Level.Value): Unit = synchronized {
     super.setLevel(newLevel)
     if (recording)

--- a/internal/util-logging/src/main/scala/sbt/internal/util/FullLogger.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/FullLogger.scala
@@ -7,7 +7,9 @@ import sbt.util._
 
 /** Promotes the simple Logger interface to the full AbstractLogger interface. */
 class FullLogger(delegate: Logger) extends BasicLogger {
+  @deprecated("No longer used.", "1.0.0")
   override val ansiCodesSupported: Boolean = delegate.ansiCodesSupported
+
   def trace(t: => Throwable): Unit = {
     if (traceEnabled)
       delegate.trace(t)

--- a/internal/util-logging/src/main/scala/sbt/internal/util/ManagedLogger.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/ManagedLogger.scala
@@ -54,5 +54,7 @@ class ManagedLogger(
         new ObjectMessage(entry)
       )
     }
+
+  @deprecated("No longer used.", "1.0.0")
   override def ansiCodesSupported = ConsoleAppender.formatEnabledInEnv
 }

--- a/internal/util-logging/src/main/scala/sbt/internal/util/MultiLogger.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/MultiLogger.scala
@@ -9,7 +9,9 @@ import sbt.util._
 // note that setting the logging level on this logger has no effect on its behavior, only
 //   on the behavior of the delegates.
 class MultiLogger(delegates: List[AbstractLogger]) extends BasicLogger {
+  @deprecated("No longer used.", "1.0.0")
   override lazy val ansiCodesSupported = delegates exists supported
+
   private[this] lazy val allSupportCodes = delegates forall supported
   private[this] def supported = (_: AbstractLogger).ansiCodesSupported
 

--- a/internal/util-logging/src/main/scala/sbt/util/Logger.scala
+++ b/internal/util-logging/src/main/scala/sbt/util/Logger.scala
@@ -27,6 +27,7 @@ abstract class Logger extends xLogger {
   // sys.process.ProcessLogger
   final def out(message: => String): Unit = log(Level.Info, message)
 
+  @deprecated("No longer used.", "1.0.0")
   def ansiCodesSupported: Boolean = false
 
   def trace(t: => Throwable): Unit


### PR DESCRIPTION
Fixes sbt/sbt#3348
Ref #101

The new logger, based on log4j separates the concern of the log producer (Logger) and the handlers that takes actions (Appender, e.g for displaying on Console). As such filtering of color should be performed only in the ConsoleAppender.

Here's the result of testing with the repro project provided by @sjrd in sbt/sbt#3348:

```scala
lazy val root = (project in file("."))
  .settings(
    scalaVersion in ThisBuild := "2.12.2",
    libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % Test,
    testOptions in Test ++= Seq(
      Tests.Argument(TestFrameworks.JUnit, "-v", "-a", "-s")
    )
  )
```
 
### sbt 1.0.0-RC2 (before)

![3348_before](https://user-images.githubusercontent.com/184683/28555150-eb882ca8-70cb-11e7-962e-54f2412ccd5e.png)

### after

![3348_after](https://user-images.githubusercontent.com/184683/28555158-f51e12dc-70cb-11e7-8a03-b9885ec6c5f8.png)
