### PR TITLE
Use event logging to send success

### DIFF
--- a/internal/util-logging/src/main/contraband-scala/sbt/internal/util/SuccessEvent.scala
+++ b/internal/util-logging/src/main/contraband-scala/sbt/internal/util/SuccessEvent.scala
@@ -1,0 +1,32 @@
+/**
+ * This code is generated using [[http://www.scala-sbt.org/contraband/ sbt-contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.util
+final class SuccessEvent private (
+  val message: String) extends Serializable {
+  
+  
+  
+  override def equals(o: Any): Boolean = o match {
+    case x: SuccessEvent => (this.message == x.message)
+    case _ => false
+  }
+  override def hashCode: Int = {
+    37 * (37 * (17 + "sbt.internal.util.SuccessEvent".##) + message.##)
+  }
+  override def toString: String = {
+    "SuccessEvent(" + message + ")"
+  }
+  protected[this] def copy(message: String = message): SuccessEvent = {
+    new SuccessEvent(message)
+  }
+  def withMessage(message: String): SuccessEvent = {
+    copy(message = message)
+  }
+}
+object SuccessEvent {
+  
+  def apply(message: String): SuccessEvent = new SuccessEvent(message)
+}

--- a/internal/util-logging/src/main/contraband-scala/sbt/internal/util/codec/JsonProtocol.scala
+++ b/internal/util-logging/src/main/contraband-scala/sbt/internal/util/codec/JsonProtocol.scala
@@ -8,4 +8,5 @@ trait JsonProtocol extends sjsonnew.BasicJsonProtocol
   with sbt.internal.util.codec.StringEventFormats
   with sbt.internal.util.codec.TraceEventFormats
   with sbt.internal.util.codec.AbstractEntryFormats
+  with sbt.internal.util.codec.SuccessEventFormats
 object JsonProtocol extends JsonProtocol

--- a/internal/util-logging/src/main/contraband-scala/sbt/internal/util/codec/SuccessEventFormats.scala
+++ b/internal/util-logging/src/main/contraband-scala/sbt/internal/util/codec/SuccessEventFormats.scala
@@ -1,0 +1,27 @@
+/**
+ * This code is generated using [[http://www.scala-sbt.org/contraband/ sbt-contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.util.codec
+import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
+trait SuccessEventFormats { self: sjsonnew.BasicJsonProtocol =>
+implicit lazy val SuccessEventFormat: JsonFormat[sbt.internal.util.SuccessEvent] = new JsonFormat[sbt.internal.util.SuccessEvent] {
+  override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.internal.util.SuccessEvent = {
+    jsOpt match {
+      case Some(js) =>
+      unbuilder.beginObject(js)
+      val message = unbuilder.readField[String]("message")
+      unbuilder.endObject()
+      sbt.internal.util.SuccessEvent(message)
+      case None =>
+      deserializationError("Expected JsObject but found None")
+    }
+  }
+  override def write[J](obj: sbt.internal.util.SuccessEvent, builder: Builder[J]): Unit = {
+    builder.beginObject()
+    builder.addField("message", obj.message)
+    builder.endObject()
+  }
+}
+}

--- a/internal/util-logging/src/main/contraband/logging.contra
+++ b/internal/util-logging/src/main/contraband/logging.contra
@@ -21,3 +21,7 @@ type TraceEvent implements sbt.internal.util.AbstractEntry {
   channelName: String
   execId: String
 }
+
+type SuccessEvent {
+  message: String!
+}

--- a/internal/util-logging/src/main/scala/sbt/internal/util/ManagedLogger.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/ManagedLogger.scala
@@ -7,6 +7,7 @@ import sjsonnew.JsonFormat
 import scala.reflect.runtime.universe.TypeTag
 import sbt.internal.util.codec.ThrowableShowLines._
 import sbt.internal.util.codec.TraceEventShowLines._
+import sbt.internal.util.codec.SuccessEventShowLines._
 import sbt.internal.util.codec.JsonProtocol._
 
 /**
@@ -27,7 +28,11 @@ class ManagedLogger(
         new ObjectMessage(StringEvent(level.toString, message, channelName, execId))
       )
     }
-  override def success(message: => String): Unit = xlogger.info(message)
+  
+  // send special event for success since it's not a real log level
+  override def success(message: => String): Unit = {
+    infoEvent[SuccessEvent](SuccessEvent(message))
+  }
 
   def registerStringCodec[A: ShowLines: TypeTag]: Unit =
     {
@@ -38,6 +43,7 @@ class ManagedLogger(
     }
   registerStringCodec[Throwable]
   registerStringCodec[TraceEvent]
+  registerStringCodec[SuccessEvent]
   final def debugEvent[A: JsonFormat: TypeTag](event: => A): Unit = logEvent(Level.Debug, event)
   final def infoEvent[A: JsonFormat: TypeTag](event: => A): Unit = logEvent(Level.Info, event)
   final def warnEvent[A: JsonFormat: TypeTag](event: => A): Unit = logEvent(Level.Warn, event)

--- a/internal/util-logging/src/main/scala/sbt/internal/util/codec/SuccessEventShowLines.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/codec/SuccessEventShowLines.scala
@@ -1,0 +1,14 @@
+package sbt
+package internal.util.codec
+
+import sbt.util.ShowLines
+import sbt.internal.util.SuccessEvent
+
+trait SuccessEventShowLines {
+  implicit val sbtSuccessEventShowLines: ShowLines[SuccessEvent] =
+    ShowLines[SuccessEvent]( (e: SuccessEvent) => {
+      Vector(e.message)
+    })
+}
+
+object SuccessEventShowLines extends SuccessEventShowLines


### PR DESCRIPTION
Fixes sbt/sbt#3213

### before (sbt 1.0.0-RC2)

![success_before](https://user-images.githubusercontent.com/184683/28591914-5275356c-7155-11e7-9b59-76e5a1b6dab9.png)

### after

_This_ is what success looks like ;)

![success](https://user-images.githubusercontent.com/184683/28591803-f7ec9fb8-7154-11e7-94f3-f790ce610647.png)
