### PR TITLE
Fix ConsoleAppender to show full stack trace

### DIFF
--- a/internal/util-logging/src/main/contraband-scala/sbt/internal/util/SuccessEvent.scala
+++ b/internal/util-logging/src/main/contraband-scala/sbt/internal/util/SuccessEvent.scala
@@ -1,0 +1,32 @@
+/**
+ * This code is generated using [[http://www.scala-sbt.org/contraband/ sbt-contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.util
+final class SuccessEvent private (
+  val message: String) extends Serializable {
+  
+  
+  
+  override def equals(o: Any): Boolean = o match {
+    case x: SuccessEvent => (this.message == x.message)
+    case _ => false
+  }
+  override def hashCode: Int = {
+    37 * (37 * (17 + "sbt.internal.util.SuccessEvent".##) + message.##)
+  }
+  override def toString: String = {
+    "SuccessEvent(" + message + ")"
+  }
+  protected[this] def copy(message: String = message): SuccessEvent = {
+    new SuccessEvent(message)
+  }
+  def withMessage(message: String): SuccessEvent = {
+    copy(message = message)
+  }
+}
+object SuccessEvent {
+  
+  def apply(message: String): SuccessEvent = new SuccessEvent(message)
+}

--- a/internal/util-logging/src/main/contraband-scala/sbt/internal/util/codec/JsonProtocol.scala
+++ b/internal/util-logging/src/main/contraband-scala/sbt/internal/util/codec/JsonProtocol.scala
@@ -8,4 +8,5 @@ trait JsonProtocol extends sjsonnew.BasicJsonProtocol
   with sbt.internal.util.codec.StringEventFormats
   with sbt.internal.util.codec.TraceEventFormats
   with sbt.internal.util.codec.AbstractEntryFormats
+  with sbt.internal.util.codec.SuccessEventFormats
 object JsonProtocol extends JsonProtocol

--- a/internal/util-logging/src/main/contraband-scala/sbt/internal/util/codec/SuccessEventFormats.scala
+++ b/internal/util-logging/src/main/contraband-scala/sbt/internal/util/codec/SuccessEventFormats.scala
@@ -1,0 +1,27 @@
+/**
+ * This code is generated using [[http://www.scala-sbt.org/contraband/ sbt-contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.util.codec
+import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
+trait SuccessEventFormats { self: sjsonnew.BasicJsonProtocol =>
+implicit lazy val SuccessEventFormat: JsonFormat[sbt.internal.util.SuccessEvent] = new JsonFormat[sbt.internal.util.SuccessEvent] {
+  override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.internal.util.SuccessEvent = {
+    jsOpt match {
+      case Some(js) =>
+      unbuilder.beginObject(js)
+      val message = unbuilder.readField[String]("message")
+      unbuilder.endObject()
+      sbt.internal.util.SuccessEvent(message)
+      case None =>
+      deserializationError("Expected JsObject but found None")
+    }
+  }
+  override def write[J](obj: sbt.internal.util.SuccessEvent, builder: Builder[J]): Unit = {
+    builder.beginObject()
+    builder.addField("message", obj.message)
+    builder.endObject()
+  }
+}
+}

--- a/internal/util-logging/src/main/contraband/logging.contra
+++ b/internal/util-logging/src/main/contraband/logging.contra
@@ -21,3 +21,7 @@ type TraceEvent implements sbt.internal.util.AbstractEntry {
   channelName: String
   execId: String
 }
+
+type SuccessEvent {
+  message: String!
+}

--- a/internal/util-logging/src/main/scala/sbt/internal/util/ManagedLogger.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/ManagedLogger.scala
@@ -7,6 +7,7 @@ import sjsonnew.JsonFormat
 import scala.reflect.runtime.universe.TypeTag
 import sbt.internal.util.codec.ThrowableShowLines._
 import sbt.internal.util.codec.TraceEventShowLines._
+import sbt.internal.util.codec.SuccessEventShowLines._
 import sbt.internal.util.codec.JsonProtocol._
 
 /**
@@ -27,7 +28,11 @@ class ManagedLogger(
         new ObjectMessage(StringEvent(level.toString, message, channelName, execId))
       )
     }
-  override def success(message: => String): Unit = xlogger.info(message)
+  
+  // send special event for success since it's not a real log level
+  override def success(message: => String): Unit = {
+    infoEvent[SuccessEvent](SuccessEvent(message))
+  }
 
   def registerStringCodec[A: ShowLines: TypeTag]: Unit =
     {
@@ -38,6 +43,7 @@ class ManagedLogger(
     }
   registerStringCodec[Throwable]
   registerStringCodec[TraceEvent]
+  registerStringCodec[SuccessEvent]
   final def debugEvent[A: JsonFormat: TypeTag](event: => A): Unit = logEvent(Level.Debug, event)
   final def infoEvent[A: JsonFormat: TypeTag](event: => A): Unit = logEvent(Level.Info, event)
   final def warnEvent[A: JsonFormat: TypeTag](event: => A): Unit = logEvent(Level.Warn, event)

--- a/internal/util-logging/src/main/scala/sbt/internal/util/StackTrace.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/StackTrace.scala
@@ -9,12 +9,13 @@ object StackTrace {
    * Return a printable representation of the stack trace associated
    * with t.  Information about t and its Throwable causes is included.
    * The number of lines to be included for each Throwable is configured
-   * via d which should be greater than or equal to zero.  If d is zero,
-   * then all elements are included up to (but not including) the first
-   * element that comes from sbt. If d is greater than zero, then up to
-   * that many lines are included, where the line for the Throwable is
-   * counted plus one line for each stack element.  Less lines will be
-   * included if there are not enough stack elements.
+   * via d which should be greater than or equal to 0.
+   *
+   * - If d is 0, then all elements are included up to (but not including)
+   *   the first element that comes from sbt.
+   * - If d is greater than 0, then up to that many lines are included,
+   *   where the line for the Throwable is counted plus one line for each stack element.
+   *   Less lines will be included if there are not enough stack elements.
    */
   def trimmed(t: Throwable, d: Int): String = {
     require(d >= 0)

--- a/internal/util-logging/src/main/scala/sbt/internal/util/codec/SuccessEventShowLines.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/codec/SuccessEventShowLines.scala
@@ -1,0 +1,14 @@
+package sbt
+package internal.util.codec
+
+import sbt.util.ShowLines
+import sbt.internal.util.SuccessEvent
+
+trait SuccessEventShowLines {
+  implicit val sbtSuccessEventShowLines: ShowLines[SuccessEvent] =
+    ShowLines[SuccessEvent]( (e: SuccessEvent) => {
+      Vector(e.message)
+    })
+}
+
+object SuccessEventShowLines extends SuccessEventShowLines


### PR DESCRIPTION
This PR is on top of https://github.com/sbt/util/pull/105 (success logging)

This is modification of crash log event logging that was added in sbt/util#85.

Instead of using the hardcoded 0 as the default value, this introduces `setTrace(..)` to `ConsoleAppender` like `BasicLogger`. Also the default value is set to `Int.MaxValue` that will display the full stack trace.

Fixes sbt/sbt#3343

### before (local SNAPSHOT)

```
$ sbt
Java HotSpot(TM) 64-Bit Server VM warning: ignoring option MaxPermSize=512M; support was removed in 8.0
[info] Loading settings from plugins.sbt ...
[error] java.lang.IllegalArgumentException: requirement failed: id must be capitalized: invalid-config-id
[error] 	at scala.Predef$.require(Predef.scala:277)
[error] java.lang.IllegalArgumentException: requirement failed: id must be capitalized: invalid-config-id
[error] Use 'last' for the full log.
Project loading failed: (r)etry, (q)uit, (l)ast, or (i)gnore?
```

### after

```
$ sbt
Java HotSpot(TM) 64-Bit Server VM warning: ignoring option MaxPermSize=512M; support was removed in 8.0
[info] Loading settings from plugins.sbt ...
[error] java.lang.IllegalArgumentException: requirement failed: id must be capitalized: invalid-config-id
[error] 	at scala.Predef$.require(Predef.scala:277)
[error] 	at sbt.librarymanagement.Configuration.<init>(Configuration.scala:19)
[error] 	at sbt.librarymanagement.Configuration$.of(Configuration.scala:72)
[error] 	at $0c11c7f9a635baf63e23$.$anonfun$$sbtdef$1(/xxx/hellotest/project/plugins.sbt:2)
[error] 	at sbt.internal.util.EvaluateSettings.$anonfun$constant$1(INode.scala:197)
[error] 	at sbt.internal.util.EvaluateSettings$MixedNode.evaluate0(INode.scala:214)
[error] 	at sbt.internal.util.EvaluateSettings$INode.evaluate(INode.scala:159)
[error] 	at sbt.internal.util.EvaluateSettings.$anonfun$submitEvaluate$1(INode.scala:82)
[error] 	at sbt.internal.util.EvaluateSettings.sbt$internal$util$EvaluateSettings$$run0(INode.scala:93)
[error] 	at sbt.internal.util.EvaluateSettings$$anon$3.run(INode.scala:89)
[error] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
[error] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
[error] 	at java.lang.Thread.run(Thread.java:748)
[error] java.lang.IllegalArgumentException: requirement failed: id must be capitalized: invalid-config-id
[error] Use 'last' for the full log.
Project loading failed: (r)etry, (q)uit, (l)ast, or (i)gnore?
```
