### PR TITLE
Don't format *.sbt files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ scala:
   - 2.12.3
 
 script:
-  - sbt -Dfile.encoding=UTF8 -J-XX:ReservedCodeCacheSize=256M "++$TRAVIS_SCALA_VERSION" mimaReportBinaryIssues scalafmt::test test:scalafmt::test sbt:scalafmt::test test
+  - sbt -Dfile.encoding=UTF8 -J-XX:ReservedCodeCacheSize=256M "++$TRAVIS_SCALA_VERSION" mimaReportBinaryIssues scalafmt::test test:scalafmt::test test
 
 cache:
   directories:

--- a/build.sbt
+++ b/build.sbt
@@ -63,6 +63,7 @@ lazy val utilRoot: Project = (project in file("."))
         description := "Util module for sbt",
         scmInfo := Some(ScmInfo(url("https://github.com/sbt/util"), "git@github.com:sbt/util.git")),
         scalafmtOnCompile := true,
+        scalafmtOnCompile in Sbt := false,
         scalafmtVersion := "1.2.0",
       )),
     commonSettings,


### PR DESCRIPTION
This adds update on load, which interacts badly with +compile.

Ref https://github.com/lucidsoftware/neo-sbt-scalafmt/issues/47
