### PR TITLE
Fixes ???, providing JValue pass-through

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import Dependencies._
 import Util._
 //import com.typesafe.tools.mima.core._, ProblemFilters._
 
-def baseVersion = "1.0.0-SNAPSHOT"
+def baseVersion = "1.0.2-SNAPSHOT"
 def internalPath = file("internal")
 
 def commonSettings: Seq[Setting[_]] = Seq(

--- a/internal/util-logging/src/main/scala/sbt/internal/util/codec/JValueFormats.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/codec/JValueFormats.scala
@@ -42,8 +42,13 @@ trait JValueFormats { self: sjsonnew.BasicJsonProtocol =>
     }
   }
 
+  // This passes through JValue, or returns JNull instead of blowing up with unimplemented.
   implicit lazy val JValueJsonReader: JR[JValue] = new JR[JValue] {
-    def read[J](j: Option[J], u: Unbuilder[J]) = ??? // Is this even possible? with no Manifest[J]?
+    def read[J](j: Option[J], u: Unbuilder[J]) = j match {
+      case Some(x: JValue) => x
+      case Some(x)         => sys.error(s"Uknown AST $x")
+      case _               => JNull
+    }
   }
 
   implicit lazy val JValueFormat: JF[JValue] =


### PR DESCRIPTION
The current implementation

```scala
def read[J](j: Option[J], u: Unbuilder[J]) = ??? // Is this even possible? with no Manifest[J]?
```

is pretty broken. When JValue appears in pseudo-case class as a stand in for `any`, and when combined with Option, this causes sudden error.

```
Exception in thread "sbt-networkchannel-56759" scala.NotImplementedError: an implementation is missing
	at scala.Predef$.$qmark$qmark$qmark(Predef.scala:284)
	at sbt.internal.util.codec.JValueFormats$$anon$4.read(JValueFormats.scala:43)
	at sbt.internal.util.codec.JValueFormats$$anon$4.read(JValueFormats.scala:42)
	at sjsonnew.AdditionalFormats$$anon$2.read(AdditionalFormats.scala:30)
	at sjsonnew.StandardFormats$OptionFormat.read(StandardFormats.scala:51)
	at sjsonnew.StandardFormats$OptionFormat.read(StandardFormats.scala:33)
	at sjsonnew.Unbuilder.readField(Unbuilder.scala:193)
....
```

This fixes the situation by providing a pass-through of `JValue` when the AST is also `JValue`, which should be like 100% of the times for us, on the reading side.