### PR TITLE
Be more aggressive when checking if a log message should be sent to the underlying logger

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: scala
 jdk: oraclejdk8
 
 scala:
-  - 2.11.11
-  - 2.12.3
+  - 2.11.12
+  - 2.12.4
 
 script:
   - sbt -Dfile.encoding=UTF8 -J-XX:ReservedCodeCacheSize=256M "++$TRAVIS_SCALA_VERSION" mimaReportBinaryIssues scalafmt::test test:scalafmt::test test

--- a/internal/util-logging/src/main/scala/sbt/util/AbtractLogger.scala
+++ b/internal/util-logging/src/main/scala/sbt/util/AbtractLogger.scala
@@ -17,9 +17,9 @@ abstract class AbstractLogger extends Logger {
   /** Defined in terms of other methods in Logger and should not be called from them. */
   final def log(event: LogEvent): Unit = {
     event match {
-      case s: Success       => success(s.msg)
-      case l: Log           => log(l.level, l.msg)
-      case t: Trace         => trace(t.exception)
+      case s: Success       => if (successEnabled) success(s.msg)
+      case l: Log           => if (atLevel(l.level)) log(l.level, l.msg)
+      case t: Trace         => if (traceEnabled) trace(t.exception)
       case setL: SetLevel   => setLevel(setL.newLevel)
       case setT: SetTrace   => setTrace(setT.level)
       case setS: SetSuccess => setSuccessEnabled(setS.enabled)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,10 +4,10 @@ import sbt.contraband.ContrabandPlugin.autoImport._
 
 object Dependencies {
   val scala210 = "2.10.6"
-  val scala211 = "2.11.11"
-  val scala212 = "2.12.3"
+  val scala211 = "2.11.12"
+  val scala212 = "2.12.4"
 
-  private val ioVersion = "1.0.0"
+  private val ioVersion = "1.0.2"
 
   private val sbtIO = "org.scala-sbt" %% "io" % ioVersion
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("org.scala-sbt" % "sbt-houserules" % "0.3.3")
 addSbtPlugin("org.scala-sbt" % "sbt-contraband" % "0.3.0")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.17")
-addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.10")
+addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.14")


### PR DESCRIPTION
https://github.com/sbt/sbt/issues/3711 has shown that substantial amount of time is spent calculating log messages that are unlikely to be displayed.

This PR introduces checks that filter out log events for disabled log levels.

It does this on two levels of abstraction which may be redundant and is deserving of critical review. The reason for this is there is non-trivial message construction is happening in `ManagedLogger` but to me changing `AbstractLogger` would offer a more general solution for all types of loggers.

Lastly, I upgraded the versions of scala as well as the scalafmt plugin.