### PR TITLE
Disable ivy log4j caller location calculation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: scala
 jdk: oraclejdk8
 
 scala:
-  - 2.11.11
-  - 2.12.3
+  - 2.11.12
+  - 2.12.4
 
 script:
   - sbt -Dfile.encoding=UTF8 -J-XX:ReservedCodeCacheSize=256M "++$TRAVIS_SCALA_VERSION" mimaReportBinaryIssues scalafmt::test test:scalafmt::test test

--- a/internal/util-logging/src/main/scala/sbt/util/LogExchange.scala
+++ b/internal/util-logging/src/main/scala/sbt/util/LogExchange.scala
@@ -31,7 +31,9 @@ sealed abstract class LogExchange {
       false,
       XLevel.DEBUG,
       name,
-      "true",
+      // disable the calculation of caller location as it is very expensive
+      // https://issues.apache.org/jira/browse/LOG4J2-153
+      "false",
       Array[AppenderRef](),
       null,
       config,

--- a/internal/util-logging/src/test/scala/ManagedLoggerSpec.scala
+++ b/internal/util-logging/src/test/scala/ManagedLoggerSpec.scala
@@ -20,6 +20,18 @@ class ManagedLoggerSpec extends FlatSpec with Matchers {
     log.infoEvent(1)
   }
 
+  it should "validate performance improvement of disabling location calculation for async loggers" in {
+    val log = LogExchange.logger("foo")
+    LogExchange.bindLoggerAppenders("foo", List(LogExchange.asyncStdout -> Level.Info))
+    val before = System.currentTimeMillis()
+    1 to 10000 foreach { _ =>
+      log.debug("test")
+    }
+    val after = System.currentTimeMillis()
+
+    log.info(s"Peformance test took: ${after - before}ms")
+  }
+
   it should "support logging Throwable out of the box" in {
     import sbt.internal.util.codec.JsonProtocol._
     val log = LogExchange.logger("foo")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,10 +4,10 @@ import sbt.contraband.ContrabandPlugin.autoImport._
 
 object Dependencies {
   val scala210 = "2.10.6"
-  val scala211 = "2.11.11"
-  val scala212 = "2.12.3"
+  val scala211 = "2.11.12"
+  val scala212 = "2.12.4"
 
-  private val ioVersion = "1.0.0"
+  private val ioVersion = "1.0.2"
 
   private val sbtIO = "org.scala-sbt" %% "io" % ioVersion
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("org.scala-sbt" % "sbt-houserules" % "0.3.3")
 addSbtPlugin("org.scala-sbt" % "sbt-contraband" % "0.3.0")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.17")
-addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.10")
+addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.14")


### PR DESCRIPTION
This is a reworking of #131 which is getting closer to the root cause of issue: If you look a little closer at https://github.com/sbt/sbt/issues/3711 you can see that most time is spent calculating the caller location for the async logger.

AFAICS the caller location is never displayed anywhere so it can be discarded. 

https://issues.apache.org/jira/browse/LOG4J2-153 however indicates this information should be constructed lazily, so I'm still a little puzzled why this takes so long.
