### PR TITLE
Convert lastModified() calls to the more precise getModifiedTime()

### DIFF
--- a/internal/util-scripted/src/main/scala/sbt/internal/scripted/FileCommands.scala
+++ b/internal/util-scripted/src/main/scala/sbt/internal/scripted/FileCommands.scala
@@ -9,7 +9,7 @@ import java.io.File
 import sbt.io.{ IO, Path }
 import sbt.io.syntax._
 import Path._
-import sbt.io.Milli.getModifiedTime
+import sbt.io.IO.getModifiedTime
 
 class FileCommands(baseDirectory: File) extends BasicStatementHandler {
   lazy val commands = commandMap
@@ -68,8 +68,7 @@ class FileCommands(baseDirectory: File) extends BasicStatementHandler {
   def newer(a: String, b: String): Unit = {
     val pathA = fromString(a)
     val pathB = fromString(b)
-    val isNewer = pathA.exists && (!pathB.exists || getModifiedTime(pathA) > getModifiedTime(
-      pathB))
+    val isNewer = pathA.exists && (!pathB.exists || getModifiedTime(pathA) > getModifiedTime(pathB))
     if (!isNewer) {
       scriptError(s"$pathA is not newer than $pathB")
     }

--- a/internal/util-scripted/src/main/scala/sbt/internal/scripted/FileCommands.scala
+++ b/internal/util-scripted/src/main/scala/sbt/internal/scripted/FileCommands.scala
@@ -9,6 +9,7 @@ import java.io.File
 import sbt.io.{ IO, Path }
 import sbt.io.syntax._
 import Path._
+import sbt.io.Milli.getModifiedTime
 
 class FileCommands(baseDirectory: File) extends BasicStatementHandler {
   lazy val commands = commandMap
@@ -67,7 +68,8 @@ class FileCommands(baseDirectory: File) extends BasicStatementHandler {
   def newer(a: String, b: String): Unit = {
     val pathA = fromString(a)
     val pathB = fromString(b)
-    val isNewer = pathA.exists && (!pathB.exists || pathA.lastModified > pathB.lastModified)
+    val isNewer = pathA.exists && (!pathB.exists || getModifiedTime(pathA) > getModifiedTime(
+      pathB))
     if (!isNewer) {
       scriptError(s"$pathA is not newer than $pathB")
     }

--- a/internal/util-scripted/src/main/scala/sbt/internal/scripted/FileCommands.scala
+++ b/internal/util-scripted/src/main/scala/sbt/internal/scripted/FileCommands.scala
@@ -68,7 +68,8 @@ class FileCommands(baseDirectory: File) extends BasicStatementHandler {
   def newer(a: String, b: String): Unit = {
     val pathA = fromString(a)
     val pathB = fromString(b)
-    val isNewer = pathA.exists && (!pathB.exists || getModifiedTime(pathA) > getModifiedTime(pathB))
+    val isNewer = pathA.exists &&
+        (!pathB.exists || IO.getModifiedTime(pathA) > IO.getModifiedTime(pathB))
     if (!isNewer) {
       scriptError(s"$pathA is not newer than $pathB")
     }

--- a/internal/util-scripted/src/main/scala/sbt/internal/scripted/FileCommands.scala
+++ b/internal/util-scripted/src/main/scala/sbt/internal/scripted/FileCommands.scala
@@ -9,7 +9,7 @@ import java.io.File
 import sbt.io.{ IO, Path }
 import sbt.io.syntax._
 import Path._
-import sbt.io.IO.getModifiedTime
+import sbt.io.IO
 
 class FileCommands(baseDirectory: File) extends BasicStatementHandler {
   lazy val commands = commandMap

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val scala211 = "2.11.12"
   val scala212 = "2.12.4"
 
-  private val ioVersion = "1.1.1"
+  private val ioVersion = "1.1.2"
 
   private val sbtIO = "org.scala-sbt" %% "io" % ioVersion
 

--- a/util-cache/src/main/scala/sbt/util/FileInfo.scala
+++ b/util-cache/src/main/scala/sbt/util/FileInfo.scala
@@ -8,6 +8,7 @@ import scala.util.control.NonFatal
 import sbt.io.Hash
 import sjsonnew.{ Builder, JsonFormat, Unbuilder, deserializationError }
 import CacheImplicits._
+import sbt.io.Milli.getModifiedTime
 
 sealed trait FileInfo { def file: File }
 sealed trait HashFileInfo extends FileInfo { def hash: List[Byte] }
@@ -88,7 +89,7 @@ object FileInfo {
     }
 
     implicit def apply(file: File): HashModifiedFileInfo =
-      FileHashModified(file.getAbsoluteFile, Hash(file).toList, file.lastModified)
+      FileHashModified(file.getAbsoluteFile, Hash(file).toList, getModifiedTime(file))
   }
 
   object hash extends Style {
@@ -145,7 +146,7 @@ object FileInfo {
     }
 
     implicit def apply(file: File): ModifiedFileInfo =
-      FileModified(file.getAbsoluteFile, file.lastModified)
+      FileModified(file.getAbsoluteFile, getModifiedTime(file))
   }
 
   object exists extends Style {

--- a/util-cache/src/main/scala/sbt/util/FileInfo.scala
+++ b/util-cache/src/main/scala/sbt/util/FileInfo.scala
@@ -6,10 +6,9 @@ package sbt.util
 import java.io.File
 import java.io.FileNotFoundException
 import scala.util.control.NonFatal
-import sbt.io.Hash
+import sbt.io.{ Hash, IO }
 import sjsonnew.{ Builder, JsonFormat, Unbuilder, deserializationError }
 import CacheImplicits._
-import sbt.io.IO.getModifiedTime
 
 sealed trait FileInfo { def file: File }
 sealed trait HashFileInfo extends FileInfo { def hash: List[Byte] }
@@ -52,13 +51,10 @@ object FilesInfo {
 
 object FileInfo {
 
-  def getModifiedTimeOrZero(file: File) = { // returns 0L if file does not exist
-    try {
-      getModifiedTime(file)
-    } catch {
-      case _: FileNotFoundException => 0L
-    }
-  }
+  // returns 0L if file does not exist
+  private def getModifiedTimeOrZero(file: File) =
+    try IO.getModifiedTime(file)
+    catch { case _: FileNotFoundException => 0L }
 
   sealed trait Style {
     type F <: FileInfo

--- a/util-cache/src/main/scala/sbt/util/FileInfo.scala
+++ b/util-cache/src/main/scala/sbt/util/FileInfo.scala
@@ -4,6 +4,7 @@
 package sbt.util
 
 import java.io.File
+import java.io.FileNotFoundException
 import scala.util.control.NonFatal
 import sbt.io.Hash
 import sjsonnew.{ Builder, JsonFormat, Unbuilder, deserializationError }
@@ -50,6 +51,15 @@ object FilesInfo {
 }
 
 object FileInfo {
+
+  def getModifiedTimeOrZero(file: File) = { // returns 0L if file does not exist
+    try {
+      getModifiedTime(file)
+    } catch {
+      case _: FileNotFoundException => 0L
+    }
+  }
+
   sealed trait Style {
     type F <: FileInfo
 
@@ -89,7 +99,7 @@ object FileInfo {
     }
 
     implicit def apply(file: File): HashModifiedFileInfo =
-      FileHashModified(file.getAbsoluteFile, Hash(file).toList, getModifiedTime(file))
+      FileHashModified(file.getAbsoluteFile, Hash(file).toList, getModifiedTimeOrZero(file))
   }
 
   object hash extends Style {
@@ -146,7 +156,7 @@ object FileInfo {
     }
 
     implicit def apply(file: File): ModifiedFileInfo =
-      FileModified(file.getAbsoluteFile, getModifiedTime(file))
+      FileModified(file.getAbsoluteFile, getModifiedTimeOrZero(file))
   }
 
   object exists extends Style {

--- a/util-cache/src/main/scala/sbt/util/FileInfo.scala
+++ b/util-cache/src/main/scala/sbt/util/FileInfo.scala
@@ -8,7 +8,7 @@ import scala.util.control.NonFatal
 import sbt.io.Hash
 import sjsonnew.{ Builder, JsonFormat, Unbuilder, deserializationError }
 import CacheImplicits._
-import sbt.io.Milli.getModifiedTime
+import sbt.io.IO.getModifiedTime
 
 sealed trait FileInfo { def file: File }
 sealed trait HashFileInfo extends FileInfo { def hash: List[Byte] }

--- a/util-cache/src/test/scala/FileInfoSpec.scala
+++ b/util-cache/src/test/scala/FileInfoSpec.scala
@@ -3,10 +3,11 @@ package sbt.util
 import sjsonnew.shaded.scalajson.ast.unsafe._
 import sjsonnew._, support.scalajson.unsafe._
 import sbt.internal.util.UnitSpec
+import sbt.io.Milli.getModifiedTime
 
 class FileInfoSpec extends UnitSpec {
   val file = new java.io.File(".").getAbsoluteFile
-  val fileInfo: ModifiedFileInfo = FileModified(file, file.lastModified())
+  val fileInfo: ModifiedFileInfo = FileModified(file, getModifiedTime(file))
   val filesInfo = FilesInfo(Set(fileInfo))
 
   it should "round trip" in assertRoundTrip(filesInfo)

--- a/util-cache/src/test/scala/FileInfoSpec.scala
+++ b/util-cache/src/test/scala/FileInfoSpec.scala
@@ -3,7 +3,7 @@ package sbt.util
 import sjsonnew.shaded.scalajson.ast.unsafe._
 import sjsonnew._, support.scalajson.unsafe._
 import sbt.internal.util.UnitSpec
-import sbt.io.Milli.getModifiedTime
+import sbt.io.IO.getModifiedTime
 
 class FileInfoSpec extends UnitSpec {
   val file = new java.io.File(".").getAbsoluteFile

--- a/util-cache/src/test/scala/FileInfoSpec.scala
+++ b/util-cache/src/test/scala/FileInfoSpec.scala
@@ -3,11 +3,11 @@ package sbt.util
 import sjsonnew.shaded.scalajson.ast.unsafe._
 import sjsonnew._, support.scalajson.unsafe._
 import sbt.internal.util.UnitSpec
-import sbt.io.IO.getModifiedTime
+import sbt.io.IO
 
 class FileInfoSpec extends UnitSpec {
   val file = new java.io.File(".").getAbsoluteFile
-  val fileInfo: ModifiedFileInfo = FileModified(file, getModifiedTime(file))
+  val fileInfo: ModifiedFileInfo = FileModified(file, IO.getModifiedTime(file))
   val filesInfo = FilesInfo(Set(fileInfo))
 
   it should "round trip" in assertRoundTrip(filesInfo)


### PR DESCRIPTION
Use the new native file modification timestamps, which return times with full millisecond precisions whenever possible. Depends on https://github.com/sbt/io/pull/92