### PR TITLE
Use IO.getModifiedTimeOrZero(file) calls

### DIFF
--- a/internal/util-scripted/src/main/scala/sbt/internal/scripted/FileCommands.scala
+++ b/internal/util-scripted/src/main/scala/sbt/internal/scripted/FileCommands.scala
@@ -69,7 +69,7 @@ class FileCommands(baseDirectory: File) extends BasicStatementHandler {
     val pathA = fromString(a)
     val pathB = fromString(b)
     val isNewer = pathA.exists &&
-      (!pathB.exists || IO.getModifiedTime(pathA) > IO.getModifiedTime(pathB))
+      (!pathB.exists || IO.lastModified(pathA) > IO.lastModified(pathB))
     if (!isNewer) {
       scriptError(s"$pathA is not newer than $pathB")
     }

--- a/internal/util-scripted/src/main/scala/sbt/internal/scripted/FileCommands.scala
+++ b/internal/util-scripted/src/main/scala/sbt/internal/scripted/FileCommands.scala
@@ -69,7 +69,7 @@ class FileCommands(baseDirectory: File) extends BasicStatementHandler {
     val pathA = fromString(a)
     val pathB = fromString(b)
     val isNewer = pathA.exists &&
-      (!pathB.exists || IO.lastModified(pathA) > IO.lastModified(pathB))
+      (!pathB.exists || IO.getModifiedTimeOrZero(pathA) > IO.getModifiedTimeOrZero(pathB))
     if (!isNewer) {
       scriptError(s"$pathA is not newer than $pathB")
     }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val scala211 = "2.11.12"
   val scala212 = "2.12.4"
 
-  private val ioVersion = "1.1.2"
+  private val ioVersion = "1.1.3"
 
   private val sbtIO = "org.scala-sbt" %% "io" % ioVersion
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.0
+sbt.version=1.0.4

--- a/util-cache/src/main/scala/sbt/util/FileInfo.scala
+++ b/util-cache/src/main/scala/sbt/util/FileInfo.scala
@@ -90,7 +90,7 @@ object FileInfo {
     }
 
     implicit def apply(file: File): HashModifiedFileInfo =
-      FileHashModified(file.getAbsoluteFile, Hash(file).toList, IO.lastModified(file))
+      FileHashModified(file.getAbsoluteFile, Hash(file).toList, IO.getModifiedTimeOrZero(file))
   }
 
   object hash extends Style {
@@ -147,7 +147,7 @@ object FileInfo {
     }
 
     implicit def apply(file: File): ModifiedFileInfo =
-      FileModified(file.getAbsoluteFile, IO.lastModified(file))
+      FileModified(file.getAbsoluteFile, IO.getModifiedTimeOrZero(file))
   }
 
   object exists extends Style {

--- a/util-cache/src/main/scala/sbt/util/FileInfo.scala
+++ b/util-cache/src/main/scala/sbt/util/FileInfo.scala
@@ -51,11 +51,6 @@ object FilesInfo {
 
 object FileInfo {
 
-  // returns 0L if file does not exist
-  private def getModifiedTimeOrZero(file: File) =
-    try IO.getModifiedTime(file)
-    catch { case _: FileNotFoundException => 0L }
-
   sealed trait Style {
     type F <: FileInfo
 
@@ -95,7 +90,7 @@ object FileInfo {
     }
 
     implicit def apply(file: File): HashModifiedFileInfo =
-      FileHashModified(file.getAbsoluteFile, Hash(file).toList, getModifiedTimeOrZero(file))
+      FileHashModified(file.getAbsoluteFile, Hash(file).toList, IO.lastModified(file))
   }
 
   object hash extends Style {
@@ -152,7 +147,7 @@ object FileInfo {
     }
 
     implicit def apply(file: File): ModifiedFileInfo =
-      FileModified(file.getAbsoluteFile, getModifiedTimeOrZero(file))
+      FileModified(file.getAbsoluteFile, IO.lastModified(file))
   }
 
   object exists extends Style {

--- a/util-cache/src/test/scala/FileInfoSpec.scala
+++ b/util-cache/src/test/scala/FileInfoSpec.scala
@@ -7,7 +7,7 @@ import sbt.io.IO
 
 class FileInfoSpec extends UnitSpec {
   val file = new java.io.File(".").getAbsoluteFile
-  val fileInfo: ModifiedFileInfo = FileModified(file, IO.lastModified(file))
+  val fileInfo: ModifiedFileInfo = FileModified(file, IO.getModifiedTimeOrZero(file))
   val filesInfo = FilesInfo(Set(fileInfo))
 
   it should "round trip" in assertRoundTrip(filesInfo)

--- a/util-cache/src/test/scala/FileInfoSpec.scala
+++ b/util-cache/src/test/scala/FileInfoSpec.scala
@@ -7,7 +7,7 @@ import sbt.io.IO
 
 class FileInfoSpec extends UnitSpec {
   val file = new java.io.File(".").getAbsoluteFile
-  val fileInfo: ModifiedFileInfo = FileModified(file, IO.getModifiedTime(file))
+  val fileInfo: ModifiedFileInfo = FileModified(file, IO.lastModified(file))
   val filesInfo = FilesInfo(Set(fileInfo))
 
   it should "round trip" in assertRoundTrip(filesInfo)


### PR DESCRIPTION
There are just too many instances in which sbt's code relies on
the `lastModified`/`setLastModified` semantics, so instead of moving
to `get`/`setModifiedTime`, we use new IO calls that offer the new
timestamp precision, but retain the old semantics.