### PR TITLE
Performance optimizations around logging

### DIFF
--- a/internal/util-logging/src/main/scala/sbt/internal/util/ConsoleAppender.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/ConsoleAppender.scala
@@ -353,8 +353,10 @@ class ConsoleAppender private[ConsoleAppender] (
    * @param msg    The message to format
    * @return The formatted message.
    */
-  private def formatted(format: String, msg: String): String =
-    s"$reset${format}${msg}$reset"
+  private def formatted(format: String, msg: String): String = {
+    val builder = new java.lang.StringBuilder(reset.length * 2 + format.length + msg.length)
+    builder.append(reset).append(format).append(msg).append(reset).toString
+  }
 
   /**
    * Select the right color for the label given `level`.
@@ -388,9 +390,14 @@ class ConsoleAppender private[ConsoleAppender] (
   ): Unit =
     out.lockObject.synchronized {
       message.lines.foreach { line =>
-        val labeledLine =
-          s"$reset[${formatted(labelColor, label)}] ${formatted(messageColor, line)}"
-        write(labeledLine)
+        val builder = new java.lang.StringBuilder(
+          labelColor.length + label.length + messageColor.length + line.length + reset.length * 3 + 3)
+        def fmted(a: String, b: String) = builder.append(reset).append(a).append(b).append(reset)
+        builder.append(reset).append('[')
+        fmted(labelColor, label)
+        builder.append("] ")
+        fmted(messageColor, line)
+        write(builder.toString)
       }
     }
 

--- a/internal/util-logging/src/main/scala/sbt/internal/util/ConsoleOut.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/ConsoleOut.scala
@@ -37,7 +37,7 @@ object ConsoleOut {
         lockObject.print(OverwriteLine)
       lockObject.println(s)
       last = Some(s)
-      current = new java.lang.StringBuffer
+      current.setLength(0)
     }
   }
 

--- a/internal/util-logging/src/main/scala/sbt/internal/util/ManagedLogger.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/ManagedLogger.scala
@@ -25,9 +25,11 @@ class ManagedLogger(
     )
   }
 
+  private val SuccessEventTag = scala.reflect.runtime.universe.typeTag[SuccessEvent]
   // send special event for success since it's not a real log level
   override def success(message: => String): Unit = {
-    infoEvent[SuccessEvent](SuccessEvent(message))
+    infoEvent[SuccessEvent](SuccessEvent(message))(implicitly[JsonFormat[SuccessEvent]],
+                                                   SuccessEventTag)
   }
 
   def registerStringCodec[A: ShowLines: TypeTag]: Unit = {


### PR DESCRIPTION
 - Cache the `TypeTag[SuccessEvent]` used in the frequently called `ManagedLogger.success`. The `TypeTag` itself has a lazy val `tpe` field that caches the `Type`, so we save some work in creating calling `tpe.toString` later on.
  - Reuse the `StringBuilder` used to buffer console output, rather than creating new one for each line.
  - Use StringBuilder rather than string interpolation in some hot code. A future version of Scala should make the interpolators just as fast, but right now there is some overhead.