### PR TITLE
fix adapted argument warning

### DIFF
--- a/util-cache/src/main/scala/sbt/util/Input.scala
+++ b/util-cache/src/main/scala/sbt/util/Input.scala
@@ -16,7 +16,7 @@ class PlainInput[J: IsoString](input: InputStream, converter: SupportConverter[J
   val isoFormat: IsoString[J] = implicitly
 
   private def readFully(): String = {
-    Using.streamReader(input, IO.utf8) { reader =>
+    Using.streamReader((input, IO.utf8)) { reader =>
       val builder = new StringBuilder()
       val bufferSize = 1024
       val buffer = new Array[Char](bufferSize)


### PR DESCRIPTION
https://travis-ci.org/sbt/util/jobs/373445819#L517

```
[warn] /home/travis/build/sbt/util/util-cache/src/main/scala/sbt/util/Input.scala:19:23: No automatic adaptation here: use explicit parentheses.
[warn]         signature: Using.apply[R](src: Source)(f: T => R): R
[warn]   given arguments: input, IO.utf8
[warn]  after adaptation: Using((input, IO.utf8): (java.io.InputStream, java.nio.charset.Charset))
[warn]     Using.streamReader(input, IO.utf8) { reader =>
[warn]                       ^
```