### PR TITLE
Output Caching: invoke output value function again, after executing output effect

### DIFF
--- a/util-tracking/src/main/scala/sbt/util/Tracked.scala
+++ b/util-tracking/src/main/scala/sbt/util/Tracked.scala
@@ -178,7 +178,7 @@ object Tracked {
     def save(store: CacheStore, value: I): Unit = {
       Hasher.hash(value) match {
         case Success(keyHash) => store.write[Long](keyHash.toLong)
-        case Failure(e)       => ()
+        case Failure(_)       => ()
       }
     }
 

--- a/util-tracking/src/main/scala/sbt/util/Tracked.scala
+++ b/util-tracking/src/main/scala/sbt/util/Tracked.scala
@@ -100,7 +100,7 @@ object Tracked {
     val changed = help.changed(store, initial)
     val result = f(changed, initial)
     if (changed) {
-      help.save(store, initial)
+      help.save(store, p())
     }
     result
   }

--- a/util-tracking/src/test/scala/sbt/util/TrackedSpec.scala
+++ b/util-tracking/src/test/scala/sbt/util/TrackedSpec.scala
@@ -18,14 +18,14 @@ class TrackedSpec extends FlatSpec {
           case (in, None) =>
             assert(in === value)
             in
-          case (in, Some(_)) =>
+          case (_, Some(_)) =>
             fail()
         }(implicitly)(value)
       assert(res0 === value)
 
       val res1 =
         Tracked.lastOutput[Int, Int](store) {
-          case (in, None) =>
+          case (_, None) =>
             fail()
           case (in, Some(read)) =>
             assert(in === otherValue)
@@ -36,7 +36,7 @@ class TrackedSpec extends FlatSpec {
 
       val res2 =
         Tracked.lastOutput[Int, Int](store) {
-          case (in, None) =>
+          case (_, None) =>
             fail()
           case (in, Some(read)) =>
             assert(in === otherValue)
@@ -44,6 +44,8 @@ class TrackedSpec extends FlatSpec {
             read
         }(implicitly)(otherValue)
       assert(res2 === value)
+
+      ()
     }
   }
 
@@ -56,14 +58,14 @@ class TrackedSpec extends FlatSpec {
           case (true, in) =>
             assert(in === input0)
             in
-          case (false, in) =>
+          case (false, _) =>
             fail()
         }(implicitly, implicitly)(input0)
       assert(res0 === input0)
 
       val res1 =
         Tracked.inputChanged[String, String](store) {
-          case (true, in) =>
+          case (true, _) =>
             fail()
           case (false, in) =>
             assert(in === input0)
@@ -71,6 +73,7 @@ class TrackedSpec extends FlatSpec {
         }(implicitly, implicitly)(input0)
       assert(res1 === input0)
 
+      ()
     }
   }
 
@@ -84,7 +87,7 @@ class TrackedSpec extends FlatSpec {
           case (true, in) =>
             assert(in === input0)
             in
-          case (false, in) =>
+          case (false, _) =>
             fail()
         }(implicitly, implicitly)(input0)
       assert(res0 === input0)
@@ -94,11 +97,12 @@ class TrackedSpec extends FlatSpec {
           case (true, in) =>
             assert(in === input1)
             in
-          case (false, in) =>
+          case (false, _) =>
             fail()
         }(implicitly, implicitly)(input1)
       assert(res1 === input1)
 
+      ()
     }
   }
 
@@ -147,6 +151,8 @@ class TrackedSpec extends FlatSpec {
       Tracked.tstamp(store) { last =>
         assert(last === 0)
       }
+
+      ()
     }
   }
 
@@ -160,6 +166,8 @@ class TrackedSpec extends FlatSpec {
         val difference = System.currentTimeMillis - last
         assert(difference < 1000)
       }
+
+      ()
     }
   }
 


### PR DESCRIPTION
fixes #168

This is a little earlier than I would normally create a PR, but I'm having trouble locally using the snapshot version of this library in a scripted test for the sbt plugin where this issue first came up. I'm hoping to get some feedback from maintainers (and any CI for the project) and will proceed accordingly.