### PR TITLE
xsbti.Position: add startOffset and endOffset 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -124,6 +124,8 @@ lazy val utilLogging = (project in internalPath / "util-logging")
       exclude[DirectMissingMethodProblem]("sbt.internal.util.SuccessEvent.copy*"),
       exclude[DirectMissingMethodProblem]("sbt.internal.util.TraceEvent.copy*"),
       exclude[DirectMissingMethodProblem]("sbt.internal.util.StringEvent.copy*"),
+      // Private final class constructor changed
+      exclude[DirectMissingMethodProblem]("sbt.util.InterfaceUtil#ConcretePosition.this"),
     ),
   )
   .configure(addSbtIO)

--- a/internal/util-interface/src/main/java/xsbti/Position.java
+++ b/internal/util-interface/src/main/java/xsbti/Position.java
@@ -18,4 +18,8 @@ public interface Position
 
 	Optional<String> sourcePath();
 	Optional<File> sourceFile();
+
+	// Default values to avoid breaking binary compatibility
+	default Optional<Integer> startOffset() { return Optional.empty(); }
+	default Optional<Integer> endOffset() { return Optional.empty(); }
 }

--- a/internal/util-interface/src/main/java/xsbti/Position.java
+++ b/internal/util-interface/src/main/java/xsbti/Position.java
@@ -22,4 +22,8 @@ public interface Position
 	// Default values to avoid breaking binary compatibility
 	default Optional<Integer> startOffset() { return Optional.empty(); }
 	default Optional<Integer> endOffset() { return Optional.empty(); }
+	default Optional<Integer> startLine() { return Optional.empty(); }
+	default Optional<Integer> startColumn() { return Optional.empty(); }
+	default Optional<Integer> endLine() { return Optional.empty(); }
+	default Optional<Integer> endColumn() { return Optional.empty(); }
 }

--- a/internal/util-logging/src/main/scala/sbt/util/InterfaceUtil.scala
+++ b/internal/util-logging/src/main/scala/sbt/util/InterfaceUtil.scala
@@ -36,6 +36,7 @@ object InterfaceUtil {
       case None    => Optional.empty[A]()
     }
 
+  // Overload to preserve binary compatibility
   def position(
       line0: Option[Integer],
       content: String,
@@ -45,7 +46,28 @@ object InterfaceUtil {
       sourcePath0: Option[String],
       sourceFile0: Option[File]
   ): Position =
-    new ConcretePosition(line0, content, offset0, pointer0, pointerSpace0, sourcePath0, sourceFile0)
+    position(line0, content, offset0, pointer0, pointerSpace0, sourcePath0, sourceFile0, None, None)
+
+  def position(
+      line0: Option[Integer],
+      content: String,
+      offset0: Option[Integer],
+      pointer0: Option[Integer],
+      pointerSpace0: Option[String],
+      sourcePath0: Option[String],
+      sourceFile0: Option[File],
+      startOffset0: Option[Integer],
+      endOffset0: Option[Integer]
+  ): Position =
+    new ConcretePosition(line0,
+                         content,
+                         offset0,
+                         pointer0,
+                         pointerSpace0,
+                         sourcePath0,
+                         sourceFile0,
+                         startOffset0,
+                         endOffset0)
 
   def problem(cat: String, pos: Position, msg: String, sev: Severity): Problem =
     new ConcreteProblem(cat, pos, msg, sev)
@@ -75,7 +97,9 @@ object InterfaceUtil {
       pointer0: Option[Integer],
       pointerSpace0: Option[String],
       sourcePath0: Option[String],
-      sourceFile0: Option[File]
+      sourceFile0: Option[File],
+      startOffset0: Option[Integer],
+      endOffset0: Option[Integer]
   ) extends Position {
     val line = o2jo(line0)
     val lineContent = content
@@ -84,6 +108,8 @@ object InterfaceUtil {
     val pointerSpace = o2jo(pointerSpace0)
     val sourcePath = o2jo(sourcePath0)
     val sourceFile = o2jo(sourceFile0)
+    override val startOffset = o2jo(startOffset0)
+    override val endOffset = o2jo(endOffset0)
   }
 
   private final class ConcreteProblem(

--- a/internal/util-logging/src/main/scala/sbt/util/InterfaceUtil.scala
+++ b/internal/util-logging/src/main/scala/sbt/util/InterfaceUtil.scala
@@ -46,7 +46,7 @@ object InterfaceUtil {
       sourcePath0: Option[String],
       sourceFile0: Option[File]
   ): Position =
-    position(line0, content, offset0, pointer0, pointerSpace0, sourcePath0, sourceFile0, None, None)
+    position(line0, content, offset0, pointer0, pointerSpace0, sourcePath0, sourceFile0, None, None, None, None, None, None)
 
   def position(
       line0: Option[Integer],
@@ -57,7 +57,11 @@ object InterfaceUtil {
       sourcePath0: Option[String],
       sourceFile0: Option[File],
       startOffset0: Option[Integer],
-      endOffset0: Option[Integer]
+      endOffset0: Option[Integer],
+      startLine0: Option[Integer],
+      startColumn0: Option[Integer],
+      endLine0: Option[Integer],
+      endColumn0: Option[Integer]
   ): Position =
     new ConcretePosition(line0,
                          content,
@@ -67,7 +71,11 @@ object InterfaceUtil {
                          sourcePath0,
                          sourceFile0,
                          startOffset0,
-                         endOffset0)
+                         endOffset0,
+                         startLine0,
+                         startColumn0,
+                         endLine0,
+                         endColumn0)
 
   def problem(cat: String, pos: Position, msg: String, sev: Severity): Problem =
     new ConcreteProblem(cat, pos, msg, sev)
@@ -99,7 +107,11 @@ object InterfaceUtil {
       sourcePath0: Option[String],
       sourceFile0: Option[File],
       startOffset0: Option[Integer],
-      endOffset0: Option[Integer]
+      endOffset0: Option[Integer],
+      startLine0: Option[Integer],
+      startColumn0: Option[Integer],
+      endLine0: Option[Integer],
+      endColumn0: Option[Integer]
   ) extends Position {
     val line = o2jo(line0)
     val lineContent = content
@@ -110,6 +122,10 @@ object InterfaceUtil {
     val sourceFile = o2jo(sourceFile0)
     override val startOffset = o2jo(startOffset0)
     override val endOffset = o2jo(endOffset0)
+    override val startLine = o2jo(startLine0)
+    override val startColumn = o2jo(startColumn0)
+    override val endLine = o2jo(endLine0)
+    override val endColumn = o2jo(endColumn0)
   }
 
   private final class ConcreteProblem(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.0
+sbt.version=1.2.1


### PR DESCRIPTION
A position now has a start, an end, and a point (the existing `offset`),
just like it does in the Scala compiler. This information is especially
useful for displaying squiggly lines in an IDE.