### PR TITLE
Adds sbt.color flag and sbt.progress flag

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -127,6 +127,8 @@ lazy val utilLogging = (project in internalPath / "util-logging")
       exclude[DirectMissingMethodProblem]("sbt.util.InterfaceUtil#ConcretePosition.this"),
       exclude[DirectMissingMethodProblem]("sbt.util.InterfaceUtil#ConcreteProblem.this"),
       exclude[ReversedMissingMethodProblem]("sbt.internal.util.ConsoleOut.flush"),
+      // This affects Scala 2.11 only it seems, so it's ok?
+      exclude[InheritedNewAbstractMethodProblem]("sbt.internal.util.codec.JsonProtocol.LogOptionFormat"),
     ),
   )
   .configure(addSbtIO)

--- a/build.sbt
+++ b/build.sbt
@@ -126,6 +126,7 @@ lazy val utilLogging = (project in internalPath / "util-logging")
       // Private final class constructors changed
       exclude[DirectMissingMethodProblem]("sbt.util.InterfaceUtil#ConcretePosition.this"),
       exclude[DirectMissingMethodProblem]("sbt.util.InterfaceUtil#ConcreteProblem.this"),
+      exclude[ReversedMissingMethodProblem]("sbt.internal.util.ConsoleOut.flush"),
     ),
   )
   .configure(addSbtIO)

--- a/internal/util-logging/src/main/contraband-scala/sbt/internal/util/LogOption.scala
+++ b/internal/util-logging/src/main/contraband-scala/sbt/internal/util/LogOption.scala
@@ -1,0 +1,15 @@
+/**
+ * This code is generated using [[http://www.scala-sbt.org/contraband/ sbt-contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.util
+/** value for logging options like color */
+sealed abstract class LogOption extends Serializable
+object LogOption {
+  
+  
+  case object Always extends LogOption
+  case object Never extends LogOption
+  case object Auto extends LogOption
+}

--- a/internal/util-logging/src/main/contraband-scala/sbt/internal/util/codec/JsonProtocol.scala
+++ b/internal/util-logging/src/main/contraband-scala/sbt/internal/util/codec/JsonProtocol.scala
@@ -9,4 +9,5 @@ trait JsonProtocol extends sjsonnew.BasicJsonProtocol
   with sbt.internal.util.codec.TraceEventFormats
   with sbt.internal.util.codec.AbstractEntryFormats
   with sbt.internal.util.codec.SuccessEventFormats
+  with sbt.internal.util.codec.LogOptionFormats
 object JsonProtocol extends JsonProtocol

--- a/internal/util-logging/src/main/contraband-scala/sbt/internal/util/codec/LogOptionFormats.scala
+++ b/internal/util-logging/src/main/contraband-scala/sbt/internal/util/codec/LogOptionFormats.scala
@@ -1,0 +1,31 @@
+/**
+ * This code is generated using [[http://www.scala-sbt.org/contraband/ sbt-contraband]].
+ */
+
+// DO NOT EDIT MANUALLY
+package sbt.internal.util.codec
+import _root_.sjsonnew.{ Unbuilder, Builder, JsonFormat, deserializationError }
+trait LogOptionFormats { self: sjsonnew.BasicJsonProtocol =>
+implicit lazy val LogOptionFormat: JsonFormat[sbt.internal.util.LogOption] = new JsonFormat[sbt.internal.util.LogOption] {
+  override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): sbt.internal.util.LogOption = {
+    jsOpt match {
+      case Some(js) =>
+      unbuilder.readString(js) match {
+        case "Always" => sbt.internal.util.LogOption.Always
+        case "Never" => sbt.internal.util.LogOption.Never
+        case "Auto" => sbt.internal.util.LogOption.Auto
+      }
+      case None =>
+      deserializationError("Expected JsString but found None")
+    }
+  }
+  override def write[J](obj: sbt.internal.util.LogOption, builder: Builder[J]): Unit = {
+    val str = obj match {
+      case sbt.internal.util.LogOption.Always => "Always"
+      case sbt.internal.util.LogOption.Never => "Never"
+      case sbt.internal.util.LogOption.Auto => "Auto"
+    }
+    builder.writeString(str)
+  }
+}
+}

--- a/internal/util-logging/src/main/contraband/logging.contra
+++ b/internal/util-logging/src/main/contraband/logging.contra
@@ -25,3 +25,10 @@ type TraceEvent implements sbt.internal.util.AbstractEntry {
 type SuccessEvent {
   message: String!
 }
+
+## value for logging options like color
+enum LogOption {
+  Always
+  Never
+  Auto
+}

--- a/internal/util-logging/src/main/scala/sbt/internal/util/ConsoleAppender.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/ConsoleAppender.scala
@@ -150,13 +150,12 @@ object ConsoleAppender {
 
   private[sbt] def parseLogOption(s: String): LogOption =
     s.toLowerCase match {
-      case "always"  => LogOption.Always
-      case "auto"    => LogOption.Auto
-      case "never"   => LogOption.Never
-      case "true"    => LogOption.Always
-      case "false"   => LogOption.Never
-      case "default" => LogOption.Auto
-      case _         => LogOption.Auto
+      case "always" => LogOption.Always
+      case "auto"   => LogOption.Auto
+      case "never"  => LogOption.Never
+      case "true"   => LogOption.Always
+      case "false"  => LogOption.Never
+      case _        => LogOption.Auto
     }
 
   private[this] val generateId: AtomicInteger = new AtomicInteger
@@ -462,12 +461,13 @@ class ConsoleAppender private[ConsoleAppender] (
   private final val DeleteLine = "\u001B[2K"
   private final val CursorLeft1000 = "\u001B[1000D"
   private def write(msg: String): Unit = {
-    if (!useFormat || !ansiCodesSupported) out.println(EscHelpers.removeEscapeSequences(msg))
-    else {
-      if (ConsoleAppender.showProgress) {
-        out.print(s"$ScrollUp$DeleteLine$msg${CursorLeft1000}")
-        out.flush()
-      } else out.println(msg)
+    if (!useFormat || !ansiCodesSupported) {
+      out.println(EscHelpers.removeEscapeSequences(msg))
+    } else if (ConsoleAppender.showProgress) {
+      out.print(s"$ScrollUp$DeleteLine$msg${CursorLeft1000}")
+      out.flush()
+    } else {
+      out.println(msg)
     }
   }
 


### PR DESCRIPTION
This implements a new sbt.color flag that takes always/auto/never/true/false value as a replacement of current sbt.log.format=true/false flag.

When neither flags are set, the default behavior is to enable color when the terminal supports ANSI and it detects an stdout console (as opposed to redirects).

This also implements a logger that grows upward, instead towards bottom.

Fixes sbt/sbt#4284
See http://eed3si9n.com/super-shell-for-sbt
