### PR TITLE
Import sbt-web's incremental build support

### DIFF
--- a/util-tracking/src/main/scala/sbt/util/incremental/OpCache.scala
+++ b/util-tracking/src/main/scala/sbt/util/incremental/OpCache.scala
@@ -1,0 +1,191 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+package sbt.util.incremental
+
+import java.io.File
+
+import sbt.util.{ FileInfo, FilesInfo }
+import sbt.util.FileInfo.Style
+import sjsonnew.{ Builder, JsonFormat, JsonReader, JsonWriter, Unbuilder, deserializationError }
+
+import scala.collection.immutable.Set
+
+/**
+ * Cache for recording which operations have successfully completed. Associates
+ * a hash of the operations' inputs (OpInputHash) with a record of the files
+ * that were accessed by the operation.
+ */
+private[incremental] final class OpCache(val style: Style) {
+  type F = style.F
+
+  private var content: Map[OpInputHash, Record] = Map.empty
+
+  def allOpInputHashes: Set[OpInputHash] = content.keySet
+  def contains(oih: OpInputHash): Boolean = {
+    content.contains(oih)
+  }
+  def getRecord(oih: OpInputHash): Option[Record] = {
+    content.get(oih)
+  }
+  def putRecord(oih: OpInputHash, record: Record): Unit = {
+    content = content + ((oih, record))
+  }
+  def removeRecord(oih: OpInputHash): Unit = {
+    content = content - oih
+  }
+  def getContent: Map[OpInputHash, Record] = content
+
+  /**
+   * A record stored in a cache. At the moment a record stores
+   * a list of files accessed, but the record could be extended to store other
+   * information in the future.
+   */
+  case class Record(filesInfo: FilesInfo[style.F], products: Set[File])
+}
+
+/**
+ * Useful methods for working with an OpCache.
+ */
+private[incremental] object OpCache {
+
+  /**
+   * Check if any of the given FileInfo objects have changed.
+   */
+  def anyFileChanged(fileInfos: Set[_ <: FileInfo], style: Style): Boolean = {
+    fileInfos.exists { fileInfo =>
+      style.apply(fileInfo.file) != fileInfo
+    }
+  }
+
+  /**
+   * Remove all operations from the cache that aren't in the given set of operations.
+   */
+  def vacuumExcept[Op](cache: OpCache, opsToKeep: Seq[Op])(
+      implicit opInputHasher: OpInputHasher[Op]
+  ): Unit = {
+    val oihSet: Set[OpInputHash] = opsToKeep.map(opInputHasher.hash).toSet
+
+    cache.allOpInputHashes
+      .filterNot(oihSet)
+      .foreach(cache.removeRecord)
+  }
+
+  /**
+   * Given a set of operations, filter out any operations that are in the cache
+   * and unchanged, and only return operations that are not in the cache or that
+   * are in the cache but have changed.
+   */
+  def newOrChanged[Op](cache: OpCache, ops: Seq[Op])(
+      implicit opInputHasher: OpInputHasher[Op]
+  ): Seq[Op] = {
+    val opsAndHashes: Seq[(Op, OpInputHash)] = ops.map(w => (w, opInputHasher.hash(w)))
+    opsAndHashes.filter {
+      case (_, wh) =>
+        cache.getRecord(wh).fold(true) { record =>
+          // Check that cached file hashes are up to date
+          val fileChanged = OpCache.anyFileChanged(record.filesInfo.files, cache.style)
+          if (fileChanged) cache.removeRecord(wh)
+          fileChanged
+        }
+    } map {
+      case (w, _) => w
+    }
+  }
+
+  /**
+   * Add the result of an operation into the cache.
+   */
+  def cacheResult(cache: OpCache, oih: OpInputHash, or: OpResult): Unit = or match {
+    case OpFailure =>
+      // Shouldn't actually be present in the cache, but clear just in case
+      if (cache.contains(oih)) cache.removeRecord(oih)
+    case OpSuccess(filesRead, filesWritten) =>
+      val fileHashes: FilesInfo[cache.style.F] = cache.style.apply(filesRead ++ filesWritten)
+      val record = cache.Record(fileHashes, filesWritten)
+      cache.putRecord(oih, record)
+  }
+
+  /**
+   * Add multiple operations and results into the cache.
+   */
+  def cacheResults[Op](cache: OpCache, results: Map[Op, OpResult])(
+      implicit opInputHasher: OpInputHasher[Op]
+  ): Unit = {
+    for ((op, or) <- results) {
+      cacheResult(cache, opInputHasher.hash(op), or)
+    }
+  }
+
+  /**
+   * Get all the products for the given ops in the cache.
+   */
+  def productsForOps[Op](cache: OpCache, ops: Set[Op])(
+      implicit opInputHasher: OpInputHasher[Op]
+  ): Set[File] = {
+    ops.flatMap { op =>
+      val record = cache.getRecord(opInputHasher.hash(op))
+      record.fold(Set.empty[File])(_.products)
+    }
+  }
+
+  implicit def jsonFormat(implicit style: Style): JsonFormat[OpCache] = {
+    import sjsonnew.BasicJsonProtocol._
+
+    new JsonFormat[OpCache] {
+      override def write[J](cache: OpCache, builder: Builder[J]): Unit = {
+
+        import cache.style.formats
+
+        implicit val recordWriter: JsonWriter[cache.Record] = new JsonWriter[cache.Record] {
+          override def write[J1](record: cache.Record, builder: Builder[J1]): Unit = {
+            builder.beginObject()
+            builder.addField("filesInfo", record.filesInfo)
+            builder.addField("products", record.products.map(_.getAbsolutePath))
+            builder.endObject()
+          }
+        }
+
+        builder.beginObject()
+        cache.content.foreach {
+          case (hash, record) =>
+            builder.addField(hash.hash, record)
+        }
+        builder.endObject()
+      }
+
+      override def read[J](jsOpt: Option[J], unbuilder: Unbuilder[J]): OpCache = {
+        val cache = new OpCache(style)
+        import cache.style.formats
+
+        val recordReader = new JsonReader[cache.Record] {
+          override def read[J1](jsOpt: Option[J1], unbuilder: Unbuilder[J1]): cache.Record = {
+            jsOpt match {
+              case Some(js) =>
+                unbuilder.beginObject(js)
+                val filesInfo = unbuilder.readField[FilesInfo[cache.F]]("filesInfo")
+                val products = unbuilder.readField[Set[String]]("products")
+                unbuilder.endObject()
+                cache.Record(filesInfo, products.map(new File(_)))
+              case None => deserializationError("Expected JsObject but found None")
+            }
+          }
+        }
+
+        jsOpt match {
+          case Some(js) =>
+            unbuilder.beginObject(js)
+            while (unbuilder.hasNextField) {
+              val (hash, value) = unbuilder.nextFieldOpt()
+              val record = recordReader.read(value, unbuilder)
+              cache.putRecord(OpInputHash(hash), record)
+            }
+            unbuilder.endObject()
+            cache
+          case None => deserializationError("Expected JsObject but found None")
+        }
+      }
+    }
+
+  }
+}

--- a/util-tracking/src/main/scala/sbt/util/incremental/OpInputHash.scala
+++ b/util-tracking/src/main/scala/sbt/util/incremental/OpInputHash.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+package sbt.util.incremental
+
+import sbt.io.Hash
+
+/**
+ * A hash of an operation's input. Used to check if two operations have the
+ * same or different inputs.
+ */
+final case class OpInputHash(hash: String)
+
+/**
+ * Factory methods for OpInputHash.
+ */
+object OpInputHash {
+
+  /**
+   * Hash the given bytes.
+   */
+  def hashBytes(bytes: Array[Byte]): OpInputHash = new OpInputHash(Hash.toHex(Hash(bytes)))
+
+  /**
+   * Hash the given string.
+   */
+  def hashString(s: String, encoding: String = "UTF-8"): OpInputHash =
+    hashBytes(s.getBytes(encoding))
+}
+
+/**
+ * Given an operation, produces a hash of its inputs.
+ */
+trait OpInputHasher[Op] {
+  def hash(op: Op): OpInputHash
+}
+
+/**
+ * Factory methods for OpInputHash.
+ */
+object OpInputHasher {
+
+  /**
+   * Construct an OpInputHash that uses the given hashing logic.
+   */
+  def apply[Op](f: Op => OpInputHash): OpInputHasher[Op] = (op: Op) => f(op)
+}

--- a/util-tracking/src/main/scala/sbt/util/incremental/OpResult.scala
+++ b/util-tracking/src/main/scala/sbt/util/incremental/OpResult.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+package sbt.util.incremental
+
+import java.io.File
+import scala.collection.immutable.Set
+
+/**
+ * The result of running an operation, either OpSuccess or OpFailure.
+ */
+sealed trait OpResult
+
+/**
+ * An operation that succeeded. Contains information about which files the
+ * operation read and wrote.
+ */
+final case class OpSuccess(filesRead: Set[File], filesWritten: Set[File]) extends OpResult
+
+/**
+ * An operation that failed.
+ */
+case object OpFailure extends OpResult

--- a/util-tracking/src/main/scala/sbt/util/incremental/package.scala
+++ b/util-tracking/src/main/scala/sbt/util/incremental/package.scala
@@ -1,0 +1,183 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+package sbt.util
+
+import java.io.File
+
+import sbt.util.FileInfo.Style
+
+/**
+ * The incremental task API lets tasks run more quickly when they are
+ * called more than once. The idea is to do less work when tasks are
+ * called a second time, by skipping any work that has already been done.
+ * In other words, tasks only perform the “incremental” work that is
+ * necessary since they were last run.
+ *
+ * To analyse which work needs to be done, a task’s work is broken up
+ * into a number of sub-operations, each of which can be run
+ * independently. Each operation takes input parameters and can read and
+ * write files. The incremental task API keeps a record of which
+ * operations have been run so that that those operations don’t need to
+ * be repeated in the future.
+ *
+ * Here is how tasks interact with the API:
+ *
+ * - Tasks call the API with a list of potential operations to perform and
+ *   with a function to run operations.
+ *
+ * - The API takes care of pruning the list of operations to find the
+ *   incremental operations that need to be run.
+ *
+ * - The API then calls the supplied function to run the pruned list of
+ *   operations. This method returns a list of results, one for each
+ *   operation.
+ *
+ * - If an operation succeeds, the details are recorded so that the
+ *   operation can be skipped in the future, if possible.
+ *
+ * Behind the scenes, runIncremental maintains a record of each operation
+ * that succeeds. It uses these records to work out which operations need
+ * to be run and which can be skipped.
+ *
+ * Each operation is assumed to take some input parameters, optionally
+ * read and write some files, and either succeed or fail when it runs. An
+ * operation which fails will always be run again even if its parameters
+ * and input files remain the same. But an operation which succeeds will
+ * only need to be run again if its input parameters change or if the
+ * contents of any files it read from or wrote to have changed.
+ */
+package object incremental {
+
+  /**
+   * Syncs operations that haven't been run before. This method is the main
+   * interface to the incremental API.
+   *
+   * This method will delete products under the following conditions:
+   *  * If the an op from a previous run doesn't exist in the current run,
+   *    all of its products that weren't produced by other ops in the
+   *    previous run or ops from the current run will be deleted.
+   *  * If an op produced a product in a previous run, but didn't produce
+   *    it in the current run, and no other op produced it, it will be
+   *    deleted.
+   *
+   * @tparam Op The Op type parameter gives the type of the individual
+   * operations. There are no restrictions on which type callers
+   * should use here. The syncIncremental method treats Op as a
+   * completely opaque type. The caller can use whatever abstract
+   * representation of operations is most convenient; functions,
+   * strings, custom classes, etc are all possible. The only
+   * requirement is that the caller must provide two arguments to
+   * allow syncIncremental to work with operations: runOps to run a
+   * sequence of operations and return the operations’ results and
+   * inputHasher to get a hash of an operation’s inputs.
+   *
+   * @tparam A The A type parameter gives the return type of the
+   * syncIncremental method. The runOps method returns a value of type
+   * A and this value is then returned by the syncIncremental method.
+   *
+   * @param cacheStore The cache store to use.
+   *
+   * @param ops The ops parameter is a list of possible operations to
+   * perform. The syncIncremental method will prune this list and call
+   * the run parameter with the pruned list.
+   *
+   * @param runOps The runOps function returns a (Map[Op,OpResult],A).
+   * The Map[Op,OpResult] is used to update the cache of operations.
+   * The A value is used by syncIncremental as its return value for
+   * syncIncremental method.
+   *
+   * Each OpResult can be either an OpSuccess or an OpFailure. If an
+   * operation succeeded, it should return the paths of any files it read
+   * from or wrote to.
+   *
+   * Example OpResults:
+   * - Read 1 file, no output file
+   *   {{{OpSuccess(filesRead = Set(sourceFile), filesWritten = Set.empty)}}}
+   * - Read 1 file, wrote 1 file
+   *   {{{OpSuccess(filesRead = Set(sourceFile), filesWritten = Set(targetFile))}}}
+   * - Read 3 files, wrote 2 files
+   *   {{{OpSuccess(filesRead = Set(a, b, c), filesWritten = Set(d, e))}}}
+   * - Failed with 1 problem
+   *   {{{OpFailure}}}
+   * - Failed with a problem, but without any details
+   *   {{{OpFailure}}}
+   * - An unexpected error which doesn’t need to be displayed to the user
+   *   in a special way
+   *   {{{throw new DecodeException(“Couldn’t compile: failed to decode ”)}}}
+   *
+   * @param inputHasher The inputHasher implicit parameter lets the syncIncremental
+   * method distinguish between operations’ input parameters. In addition to
+   * reading and writing files, operations usually take input
+   * parameters, for example compilation settings. The incremental API
+   * doesn’t need to know the content of these parameters, but it does
+   * need to be able to tell if parameters are the same or different.
+   * Callers must provide an implicit OpInputHasher so that the API can
+   * distinguish different operations’ parameters.
+   *
+   * @return A tuple of all the output files, including those that were
+   *         produced by a previous run and didn't need to be re run, and
+   *         the result of the runOps method.
+   */
+  def syncIncremental[Op, A](cacheStore: CacheStore, ops: Seq[Op])(
+      runOps: Seq[Op] => (Map[Op, OpResult], A)
+  )(implicit inputHasher: OpInputHasher[Op], style: Style): (Set[File], A) = {
+
+    val cache: OpCache = cacheStore.read[OpCache](new OpCache(style))
+
+    // Before vacuuming the cache, find out what the old cache had produced
+    val allOldProducts = cache.getContent.values.flatMap(_.products).toSet
+
+    // Clear out any unknown operations from the existing cache
+    OpCache.vacuumExcept(cache, ops)
+
+    // Work out the minimal set of ops we need to run and run them
+    val prunedOps: Seq[Op] = OpCache.newOrChanged(cache, ops)
+    val (results: Map[Op, OpResult], finalResult) = runOps(prunedOps)
+
+    // Check returned results are all within the set of given ops
+    val prunedOpsSet: Set[Op] = prunedOps.toSet
+    val resultOpsSet: Set[Op] = results.keySet
+    val unexpectedOps: Set[Op] = resultOpsSet -- prunedOpsSet
+    if (unexpectedOps.nonEmpty) {
+      throw new IllegalArgumentException(
+        s"runOps function returned results for unknown ops: $unexpectedOps"
+      )
+    }
+
+    // Work out what the current valid products are
+    val opsSet: Set[Op] = ops.toSet
+    val oldProductsToKeep = OpCache.productsForOps(cache, opsSet -- prunedOpsSet)
+    val newProducts = results.values.flatMap {
+      case OpFailure              => Set.empty[File]
+      case OpSuccess(_, products) => products
+    }.toSet
+    val currentProducts = oldProductsToKeep ++ newProducts
+
+    // Delete all products that weren't produced by previous non expired ops, or by the current run
+    val productsToDelete = allOldProducts -- currentProducts
+    productsToDelete.filterNot(_.isDirectory).foreach(_.delete())
+
+    // Update the cache with the new information (vacuuming, new results)
+    OpCache.cacheResults(cache, results)
+    cacheStore.write(cache)
+
+    (currentProducts, finalResult)
+  }
+
+  /**
+   * A simple OpInputHasher, based on a hash of the Op's toString value. This
+   * hasher can be used if the Op includes all relevant operation input
+   * information in it's toString representation. If not, then another hasher
+   * should be used, e.g.
+   *
+   * {{{
+   * implicit val fileAndOptionsHasher = OpInputHasher[File]{ file =>
+   *   OpInputHash.hashString(file.toString + “|” + options.toString))
+   * }
+   * }}}
+   */
+  implicit def toStringInputHasher[Op]: OpInputHasher[Op] =
+    OpInputHasher[Op](op => OpInputHash.hashString(op.toString))
+
+}

--- a/util-tracking/src/test/scala/sbt/util/incremental/IncrementalSpec.scala
+++ b/util-tracking/src/test/scala/sbt/util/incremental/IncrementalSpec.scala
@@ -1,0 +1,742 @@
+package sbt.util.incremental
+
+import java.io.File
+
+import org.scalatest.{ Matchers, WordSpec }
+import sbt.io.IO
+import sbt.io.syntax._
+import sbt.util.{ CacheStore, FileInfo }
+
+class IncrementalSpec extends WordSpec with Matchers {
+
+  implicit val style = FileInfo.hash
+
+  "the runIncremental method" should {
+
+    "always perform an op when there's no cache file" in {
+      withStore { (cacheStore, tmpDir) =>
+        syncIncremental(cacheStore, List("op1")) { prunedOps =>
+          (
+            Map[String, OpResult]("op1" -> OpFailure),
+            prunedOps should ===(List("op1"))
+          )
+        }
+      }
+    }
+
+    "rerun an op when it failed last time" in {
+      withStore { (cacheStore, tmpDir) =>
+        syncIncremental(cacheStore, List("op1")) { prunedOps =>
+          (
+            Map("op1" -> OpFailure),
+            prunedOps should ===(List("op1"))
+          )
+        }
+        syncIncremental(cacheStore, List("op1")) { prunedOps =>
+          (
+            Map("op1" -> OpFailure),
+            prunedOps should ===(List("op1"))
+          )
+        }
+      }
+    }
+
+    "skip an op if nothing's changed" in {
+      withStore { (cacheStore, tmpDir) =>
+        val file1 = new File(tmpDir, "1")
+        IO.write(file1, "x")
+
+        syncIncremental(cacheStore, List("op1")) { prunedOps =>
+          (
+            Map("op1" -> OpSuccess(filesRead = Set(file1), filesWritten = Set())),
+            prunedOps should ===(List("op1"))
+          )
+        }
+
+        syncIncremental(cacheStore, List("op1")) { prunedOps =>
+          (
+            Map.empty,
+            prunedOps shouldBe empty
+          )
+        }
+      }
+    }
+
+    "rerun an op when the file it read has changed" in {
+      withStore { (cacheStore, tmpDir) =>
+        val file1 = new File(tmpDir, "1")
+        IO.write(file1, "x")
+        val file2 = new File(tmpDir, "2")
+        IO.write(file1, "x")
+
+        syncIncremental(cacheStore, List("op1")) { prunedOps =>
+          (
+            Map("op1" -> OpSuccess(filesRead = Set(file1), filesWritten = Set(file2))),
+            prunedOps should ===(List("op1"))
+          )
+        }
+
+        IO.write(file1, "y")
+
+        syncIncremental(cacheStore, List("op1")) { prunedOps =>
+          (
+            Map.empty,
+            prunedOps should ===(List("op1"))
+          )
+        }
+      }
+    }
+
+    "rerun an op when the file it wrote has changed" in {
+      withStore { (cacheStore, tmpDir) =>
+        val file1 = new File(tmpDir, "1")
+
+        syncIncremental(cacheStore, List("op1")) { prunedOps =>
+          IO.write(file1, "x")
+          (
+            Map("op1" -> OpSuccess(filesRead = Set(), filesWritten = Set(file1))),
+            prunedOps should ===(List("op1"))
+          )
+        }
+
+        IO.write(file1, "y")
+
+        syncIncremental(cacheStore, List("op1")) { prunedOps =>
+          (
+            Map.empty,
+            prunedOps should ===(List("op1"))
+          )
+        }
+      }
+    }
+
+    "rerun an op when the file it wrote has been deleted" in {
+      withStore { (cacheStore, tmpDir) =>
+        val file1 = new File(tmpDir, "1")
+
+        syncIncremental(cacheStore, List("op1")) { prunedOps =>
+          IO.write(file1, "x")
+          (
+            Map("op1" -> OpSuccess(filesRead = Set(), filesWritten = Set(file1))),
+            prunedOps should ===(List("op1"))
+          )
+        }
+
+        IO.delete(file1)
+
+        syncIncremental(cacheStore, List("op1")) { prunedOps =>
+          (
+            Map.empty,
+            prunedOps should ===(List("op1"))
+          )
+        }
+      }
+    }
+
+    "rerun an op when some of the files it read have changed" in {
+      withStore { (cacheStore, tmpDir) =>
+        val file1 = new File(tmpDir, "1")
+        val file2 = new File(tmpDir, "2")
+        IO.write(file1, "x")
+        IO.write(file2, "x")
+
+        syncIncremental(cacheStore, List("op1")) { prunedOps =>
+          (
+            Map("op1" -> OpSuccess(filesRead = Set(file1, file2), filesWritten = Set())),
+            prunedOps should ===(List("op1"))
+          )
+        }
+
+        IO.write(file2, "y")
+
+        syncIncremental(cacheStore, List("op1")) { prunedOps =>
+          (
+            Map.empty,
+            prunedOps should ===(List("op1"))
+          )
+        }
+      }
+    }
+
+    "rerun an op when some of the files it wrote have changed" in {
+      withStore { (cacheStore, tmpDir) =>
+        val file1 = new File(tmpDir, "1")
+        val file2 = new File(tmpDir, "2")
+
+        syncIncremental(cacheStore, List("op1")) { prunedOps =>
+          IO.write(file1, "x")
+          IO.write(file2, "x")
+          (
+            Map("op1" -> OpSuccess(filesRead = Set(), filesWritten = Set(file1, file2))),
+            prunedOps should ===(List("op1"))
+          )
+        }
+
+        IO.write(file2, "y")
+
+        syncIncremental(cacheStore, List("op1")) { prunedOps =>
+          (
+            Map.empty,
+            prunedOps should ===(List("op1"))
+          )
+        }
+      }
+    }
+
+    "run multiple ops" in {
+      withStore { (cacheStore, tmpDir) =>
+        val file1 = new File(tmpDir, "1")
+        val file2 = new File(tmpDir, "2")
+        val file3 = new File(tmpDir, "3")
+        val file4 = new File(tmpDir, "4")
+        IO.write(file1, "x")
+        IO.write(file2, "x")
+        IO.write(file3, "x")
+        IO.write(file4, "x")
+
+        syncIncremental(cacheStore, List("op1", "op2", "op3", "op4")) { prunedOps =>
+          (
+            Map(
+              "op1" -> OpSuccess(filesRead = Set(file1), filesWritten = Set()),
+              "op2" -> OpSuccess(filesRead = Set(file2), filesWritten = Set(file3)),
+              "op3" -> OpSuccess(filesRead = Set(), filesWritten = Set(file4)),
+              "op4" -> OpFailure
+            ),
+            prunedOps should ===(List("op1", "op2", "op3", "op4"))
+          )
+        }
+
+        IO.write(file1, "y")
+        IO.write(file4, "y")
+
+        syncIncremental(cacheStore, List("op1", "op2", "op3", "op4")) { prunedOps =>
+          (
+            Map(
+              "op1" -> OpSuccess(filesRead = Set(file1), filesWritten = Set()),
+              "op3" -> OpSuccess(filesRead = Set(), filesWritten = Set(file4)),
+              "op4" -> OpFailure
+            ),
+            prunedOps should ===(List("op1", "op3", "op4"))
+          )
+        }
+      }
+    }
+
+    "vacuum unneeded ops from the cache" in {
+      withStore { (cacheStore, tmpDir) =>
+        // Create an empty cache
+        syncIncremental(cacheStore, List[String]()) { prunedOps =>
+          (
+            Map.empty,
+            prunedOps shouldBe empty
+          )
+        }
+
+        val file1 = new File(tmpDir, "1")
+        IO.write(file1, "x")
+
+        // Run with a successful op that will be cached
+
+        syncIncremental(cacheStore, List("op1")) { prunedOps =>
+          (
+            Map("op1" -> OpSuccess(filesRead = Set(file1), filesWritten = Set())),
+            prunedOps should ===(List("op1"))
+          )
+        }
+
+        cacheStore.read[OpCache]().getContent should not be empty
+
+        // Run with different set of ops - should vacuum old ops
+
+        syncIncremental(cacheStore, List("op9")) { prunedOps =>
+          (
+            Map("op9" -> OpFailure),
+            prunedOps should ===(List("op9"))
+          )
+        }
+
+        // Check cache file is empty again, i.e. op1 has been vacuumed
+
+        cacheStore.read[OpCache]().getContent shouldBe empty
+
+      }
+    }
+
+    "rerun an op if its hash changes" in {
+      withStore { (cacheStore, tmpDir) =>
+        val file1 = new File(tmpDir, "1")
+        val file2 = new File(tmpDir, "2")
+        IO.write(file1, "x")
+        IO.write(file2, "x")
+
+        var hashPrefix = ""
+        implicit val hasher = OpInputHasher[String](op => OpInputHash.hashString(hashPrefix + op))
+
+        // Cache ops with an initial hash prefix
+
+        hashPrefix = "1/"
+
+        syncIncremental(cacheStore, List("op1")) { prunedOps =>
+          (
+            Map("op1" -> OpSuccess(filesRead = Set(file1), filesWritten = Set(file2))),
+            prunedOps should ===(List("op1"))
+          )
+        }
+
+        // No ops should run because we leave the hash prefix the same
+
+        hashPrefix = "1/"
+
+        syncIncremental(cacheStore, List("op1")) { prunedOps =>
+          (
+            Map(),
+            prunedOps shouldBe empty
+          )
+        }
+
+        // All ops should run again because we changed the hash prefix
+
+        hashPrefix = "2/"
+
+        syncIncremental(cacheStore, List("op1")) { prunedOps =>
+          (
+            Map("op1" -> OpSuccess(filesRead = Set(file1), filesWritten = Set(file2))),
+            prunedOps should ===(List("op1"))
+          )
+        }
+      }
+    }
+
+    "fail when runOps gives result for unknown op" in {
+      withStore { (cacheStore, tmpDir) =>
+        an[IllegalArgumentException] should be thrownBy syncIncremental(cacheStore, List("op1")) {
+          prunedOps =>
+            (
+              Map[String, OpResult]("op2" -> OpFailure),
+              prunedOps should ===(List("op1"))
+            )
+        }
+      }
+    }
+
+  }
+
+  "the syncIncremental method" should {
+
+    "always perform an op when there's no cache file" in {
+      withStore { (cacheStore, tmpDir) =>
+        syncIncremental(cacheStore, List("op1")) { prunedOps =>
+          (
+            Map[String, OpResult]("op1" -> OpFailure),
+            prunedOps should ===(List("op1"))
+          )
+        }
+      }
+    }
+
+    "rerun an op when it failed last time" in {
+      withStore { (cacheStore, tmpDir) =>
+        syncIncremental(cacheStore, List("op1")) { prunedOps =>
+          (
+            Map("op1" -> OpFailure),
+            prunedOps should ===(List("op1"))
+          )
+        }
+        syncIncremental(cacheStore, List("op1")) { prunedOps =>
+          (
+            Map("op1" -> OpFailure),
+            prunedOps should ===(List("op1"))
+          )
+        }
+      }
+    }
+
+    "skip an op if nothing's changed" in {
+      withStore { (cacheStore, tmpDir) =>
+        val file1 = new File(tmpDir, "1")
+        IO.write(file1, "x")
+
+        syncIncremental(cacheStore, List("op1")) { prunedOps =>
+          (
+            Map("op1" -> OpSuccess(filesRead = Set(file1), filesWritten = Set())),
+            prunedOps should ===(List("op1"))
+          )
+        }
+        syncIncremental(cacheStore, List("op1")) { prunedOps =>
+          (
+            Map.empty,
+            prunedOps shouldBe empty
+          )
+        }
+      }
+    }
+
+    "rerun an op when the file it read has changed" in {
+      withStore { (cacheStore, tmpDir) =>
+        val file1 = new File(tmpDir, "1")
+        IO.write(file1, "x")
+        val file2 = new File(tmpDir, "2")
+        IO.write(file1, "x")
+
+        syncIncremental(cacheStore, List("op1")) { prunedOps =>
+          (
+            Map("op1" -> OpSuccess(filesRead = Set(file1), filesWritten = Set(file2))),
+            prunedOps should ===(List("op1"))
+          )
+        }
+
+        IO.write(file1, "y")
+
+        syncIncremental(cacheStore, List("op1")) { prunedOps =>
+          (
+            Map.empty,
+            prunedOps should ===(List("op1"))
+          )
+        }
+      }
+    }
+
+    "rerun an op when the file it wrote has changed" in {
+      withStore { (cacheStore, tmpDir) =>
+        val file1 = new File(tmpDir, "1")
+
+        syncIncremental(cacheStore, List("op1")) { prunedOps =>
+          IO.write(file1, "x")
+          (
+            Map("op1" -> OpSuccess(filesRead = Set(), filesWritten = Set(file1))),
+            prunedOps should ===(List("op1"))
+          )
+        }
+
+        IO.write(file1, "y")
+
+        syncIncremental(cacheStore, List("op1")) { prunedOps =>
+          (
+            Map.empty,
+            prunedOps should ===(List("op1"))
+          )
+        }
+      }
+    }
+
+    "rerun an op when the file it wrote has been deleted" in {
+      withStore { (cacheStore, tmpDir) =>
+        val file1 = new File(tmpDir, "1")
+
+        syncIncremental(cacheStore, List("op1")) { prunedOps =>
+          IO.write(file1, "x")
+          (
+            Map("op1" -> OpSuccess(filesRead = Set(), filesWritten = Set(file1))),
+            prunedOps should ===(List("op1"))
+          )
+        }
+
+        IO.delete(file1)
+
+        syncIncremental(cacheStore, List("op1")) { prunedOps =>
+          (
+            Map.empty,
+            prunedOps should ===(List("op1"))
+          )
+        }
+      }
+    }
+
+    "rerun an op when some of the files it read have changed" in {
+      withStore { (cacheStore, tmpDir) =>
+        val file1 = new File(tmpDir, "1")
+        val file2 = new File(tmpDir, "2")
+        IO.write(file1, "x")
+        IO.write(file2, "x")
+
+        syncIncremental(cacheStore, List("op1")) { prunedOps =>
+          (
+            Map("op1" -> OpSuccess(filesRead = Set(file1, file2), filesWritten = Set())),
+            prunedOps should ===(List("op1"))
+          )
+        }
+
+        IO.write(file2, "y")
+
+        syncIncremental(cacheStore, List("op1")) { prunedOps =>
+          (
+            Map.empty,
+            prunedOps should ===(List("op1"))
+          )
+        }
+      }
+    }
+
+    "rerun an op when some of the files it wrote have changed" in {
+      withStore { (cacheStore, tmpDir) =>
+        val file1 = new File(tmpDir, "1")
+        val file2 = new File(tmpDir, "2")
+
+        syncIncremental(cacheStore, List("op1")) { prunedOps =>
+          IO.write(file1, "x")
+          IO.write(file2, "x")
+          (
+            Map("op1" -> OpSuccess(filesRead = Set(), filesWritten = Set(file1, file2))),
+            prunedOps should ===(List("op1"))
+          )
+        }
+
+        IO.write(file2, "y")
+
+        syncIncremental(cacheStore, List("op1")) { prunedOps =>
+          (
+            Map.empty,
+            prunedOps should ===(List("op1"))
+          )
+        }
+      }
+    }
+
+    "run multiple ops" in {
+      withStore { (cacheStore, tmpDir) =>
+        val file1 = new File(tmpDir, "1")
+        val file2 = new File(tmpDir, "2")
+        val file3 = new File(tmpDir, "3")
+        val file4 = new File(tmpDir, "4")
+        IO.write(file1, "x")
+        IO.write(file2, "x")
+        IO.write(file3, "x")
+        IO.write(file4, "x")
+
+        syncIncremental(cacheStore, List("op1", "op2", "op3", "op4")) { prunedOps =>
+          (
+            Map(
+              "op1" -> OpSuccess(filesRead = Set(file1), filesWritten = Set()),
+              "op2" -> OpSuccess(filesRead = Set(file2), filesWritten = Set(file3)),
+              "op3" -> OpSuccess(filesRead = Set(), filesWritten = Set(file4)),
+              "op4" -> OpFailure
+            ),
+            prunedOps should ===(List("op1", "op2", "op3", "op4"))
+          )
+        }
+
+        IO.write(file1, "y")
+        IO.write(file4, "y")
+
+        syncIncremental(cacheStore, List("op1", "op2", "op3", "op4")) { prunedOps =>
+          (
+            Map(
+              "op1" -> OpSuccess(filesRead = Set(file1), filesWritten = Set()),
+              "op3" -> OpSuccess(filesRead = Set(), filesWritten = Set(file4)),
+              "op4" -> OpFailure
+            ),
+            prunedOps should ===(List("op1", "op3", "op4"))
+          )
+        }
+      }
+    }
+
+    "vacuum unneeded ops from the cache" in {
+      withStore { (cacheStore, tmpDir) =>
+        // Create an empty cache
+        syncIncremental(cacheStore, List[String]()) { prunedOps =>
+          (
+            Map.empty,
+            prunedOps shouldBe empty
+          )
+        }
+
+        val file1 = new File(tmpDir, "1")
+        IO.write(file1, "x")
+
+        // Run with a successful op that will be cached
+
+        syncIncremental(cacheStore, List("op1")) { prunedOps =>
+          (
+            Map("op1" -> OpSuccess(filesRead = Set(file1), filesWritten = Set())),
+            prunedOps should ===(List("op1"))
+          )
+        }
+
+        cacheStore.read[OpCache]().getContent should not be empty
+
+        // Run with different set of ops - should vacuum old ops
+
+        syncIncremental(cacheStore, List("op9")) { prunedOps =>
+          (
+            Map("op9" -> OpFailure),
+            prunedOps should ===(List("op9"))
+          )
+        }
+
+        // Check cache file is empty again, i.e. op1 has been vacuumed
+        cacheStore.read[OpCache]().getContent shouldBe empty
+
+      }
+    }
+
+    "rerun an op if its hash changes" in {
+      withStore { (cacheStore, tmpDir) =>
+        val file1 = new File(tmpDir, "1")
+        val file2 = new File(tmpDir, "2")
+        IO.write(file1, "x")
+        IO.write(file2, "x")
+
+        var hashPrefix = ""
+        implicit val hasher = OpInputHasher[String](op => OpInputHash.hashString(hashPrefix + op))
+
+        // Cache ops with an initial hash prefix
+
+        hashPrefix = "1/"
+
+        syncIncremental(cacheStore, List("op1")) { prunedOps =>
+          (
+            Map("op1" -> OpSuccess(filesRead = Set(file1), filesWritten = Set(file2))),
+            prunedOps should ===(List("op1"))
+          )
+        }
+
+        // No ops should run because we leave the hash prefix the same
+
+        hashPrefix = "1/"
+
+        syncIncremental(cacheStore, List("op1")) { prunedOps =>
+          (
+            Map(),
+            prunedOps shouldBe empty
+          )
+        }
+
+        // All ops should run again because we changed the hash prefix
+
+        hashPrefix = "2/"
+
+        syncIncremental(cacheStore, List("op1")) { prunedOps =>
+          (
+            Map("op1" -> OpSuccess(filesRead = Set(file1), filesWritten = Set(file2))),
+            prunedOps should ===(List("op1"))
+          )
+        }
+      }
+    }
+
+    "fail when runOps gives result for unknown op" in {
+      withStore { (cacheStore, tmpDir) =>
+        an[IllegalArgumentException] should be thrownBy syncIncremental(cacheStore, List("op1")) {
+          prunedOps =>
+            (
+              Map[String, OpResult]("op2" -> OpFailure),
+              prunedOps should ===(List("op1"))
+            )
+        }
+      }
+    }
+
+    "delete a file if a previous op has been removed" in {
+      withStore { (cacheStore, tmpDir) =>
+        val file1 = new File(tmpDir, "1")
+        val file2 = new File(tmpDir, "2")
+
+        syncIncremental(cacheStore, List("op1", "op2")) { prunedOps =>
+          IO.write(file1, "x")
+          IO.write(file2, "x")
+          (
+            Map[String, OpResult](
+              "op1" -> OpSuccess(Set.empty, Set(file1)),
+              "op2" -> OpSuccess(Set.empty, Set(file2))
+            ),
+            ()
+          )
+        }
+        val (outputFiles, _) = syncIncremental(cacheStore, List("op1")) { prunedOps =>
+          (
+            Map.empty[String, OpResult],
+            prunedOps shouldBe empty
+          )
+        }
+
+        outputFiles should ===(Set(file1))
+
+        file1 should exist
+        file2 shouldNot exist
+      }
+    }
+
+    "delete a file if it's no longer produced by an op" in {
+      withStore { (cacheStore, tmpDir) =>
+        val infile = new File(tmpDir, "in")
+        val file1 = new File(tmpDir, "1")
+        val file2 = new File(tmpDir, "2")
+
+        IO.write(infile, "1")
+
+        syncIncremental(cacheStore, List("op1")) { prunedOps =>
+          IO.write(file1, "x")
+          IO.write(file2, "x")
+          (
+            Map[String, OpResult](
+              "op1" -> OpSuccess(Set(infile), Set(file1, file2))
+            ),
+            ()
+          )
+        }
+
+        IO.write(infile, "2")
+
+        val (outputFiles, _) = syncIncremental(cacheStore, List("op1")) { prunedOps =>
+          (
+            Map[String, OpResult](
+              "op1" -> OpSuccess(Set(infile), Set(file1))
+            ),
+            prunedOps should ===(List("op1"))
+          )
+        }
+
+        outputFiles should ===(Set(file1))
+
+        file1 should exist
+        file2 shouldNot exist
+      }
+    }
+
+    "not delete a file if it's produced by another op" in {
+      withStore { (cacheStore, tmpDir) =>
+        val file1 = new File(tmpDir, "1")
+        val file2 = new File(tmpDir, "2")
+        val infile = new File(tmpDir, "in")
+
+        syncIncremental(cacheStore, List("op1", "op2")) { prunedOps =>
+          IO.write(file1, "x")
+          IO.write(file2, "x")
+          (
+            Map[String, OpResult](
+              "op1" -> OpSuccess(Set(infile), Set(file1)),
+              "op2" -> OpSuccess(Set.empty, Set(file2))
+            ),
+            ()
+          )
+        }
+
+        IO.write(infile, "2")
+
+        val (outputFiles, _) = syncIncremental(cacheStore, List("op1", "op3")) { prunedOps =>
+          (
+            Map[String, OpResult](
+              "op1" -> OpSuccess(Set(infile), Set.empty),
+              "op3" -> OpSuccess(Set.empty, Set(file1, file2))
+            ),
+            ()
+          )
+        }
+
+        outputFiles should ===(Set(file1, file2))
+
+        file1 should exist
+        file2 should exist
+      }
+    }
+
+  }
+
+  private def withStore(f: (CacheStore, File) => Any): Unit = {
+    val _ = IO.withTemporaryDirectory { tmp =>
+      val store = CacheStore(tmp / "cache-store")
+      f(store, tmp)
+    }
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt/issues/4940

This is an import of sbt-webs incremental build support:

https://github.com/sbt/sbt-web/blob/8ddcba1d8a27da79071d2af9c7734524b910f542/src/main/scala/com/typesafe/sbt/web/incremental/package.scala

This offers change tracking not just of files, but of settings as well, and also allows for including input files that are not discovered until compilation (eg files that are imported).

It's been successfully used by a large number of sbt-web plugins, and would be useful outside of sbt-web too, anything that does compilation, can track dependent files of a single compilation unit, and is dependent upon user defined settings, would find it useful.

It has been changed from sbt-web to use CacheStore with JSON, and also to use the FileInfo.Style abstraction to allow users to select whether they want hashing or last modified change detection - sbt-web only used hashing.