### PR TITLE
reimplement stacktrace suppression

### DIFF
--- a/internal/util-logging/src/main/scala/sbt/internal/util/StackTrace.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/StackTrace.scala
@@ -20,6 +20,9 @@ object StackTrace {
    * - If d is greater than 0, then up to that many lines are included,
    *   where the line for the Throwable is counted plus one line for each stack element.
    *   Less lines will be included if there are not enough stack elements.
+   *
+   * See also ConsoleAppender where d <= 2 is treated specially by
+   * printing a prepared statement.
    */
   def trimmedLines(t: Throwable, d: Int): List[String] = {
     require(d >= 0)


### PR DESCRIPTION
Ref https://github.com/sbt/sbt/issues/4964

### before

```scala
sbt:hello> check
[error] java.lang.RuntimeException: boom
[error] 	at scala.sys.package$.error(package.scala:30)
[error] 	at $0d89407eaa29f35a5d10$.$anonfun$$sbtdef$1(/Users/eed3si9n/work/hellotest/build.sbt:14)
[error] 	at sbt.std.Transform$$anon$3.$anonfun$apply$2(Transform.scala:46)
[error] 	at sbt.std.Transform$$anon$4.work(Transform.scala:67)
[error] 	at sbt.Execute.$anonfun$submit$2(Execute.scala:280)
[error] 	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:19)
[error] 	at sbt.Execute.work(Execute.scala:289)
[error] 	at sbt.Execute.$anonfun$submit$1(Execute.scala:280)
[error] 	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:178)
[error] 	at sbt.CompletionService$$anon$2.call(CompletionService.scala:37)
[error] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error] 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
[error] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[error] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[error] 	at java.lang.Thread.run(Thread.java:748)
[error] (check) boom
[error] Total time: 0 s, completed Aug 20, 2019 11:35:47 AM
```

### after

```scala
sbt:hello> check
[error] Stack trace suppressed: run last check for the full output.
[error] (check) boom
[error] Total time: 0 s, completed Aug 20, 2019 12:30:48 PM
```
