### PR TITLE
Unbreak binary compatibility

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -152,15 +152,6 @@ lazy val utilCache = (project in file("util-cache"))
     libraryDependencies ++= Seq(scalaTest),
     mimaSettings,
     mimaBinaryIssueFilters ++= Seq(
-      // These are private case classes that have changed
-      exclude[IncompatibleMethTypeProblem]("sbt.util.FileHashModified.apply"),
-      exclude[IncompatibleResultTypeProblem]("sbt.util.FileHashModified.copy$default$2"),
-      exclude[IncompatibleMethTypeProblem]("sbt.util.FileHashModified.copy"),
-      exclude[IncompatibleMethTypeProblem]("sbt.util.FileHashModified.this"),
-      exclude[IncompatibleMethTypeProblem]("sbt.util.FileHash.apply"),
-      exclude[IncompatibleResultTypeProblem]("sbt.util.FileHash.copy$default$2"),
-      exclude[IncompatibleMethTypeProblem]("sbt.util.FileHash.copy"),
-      exclude[IncompatibleMethTypeProblem]("sbt.util.FileHash.this"),
       // Added a method to a sealed trait, technically not a problem for Scala
       exclude[ReversedMissingMethodProblem]("sbt.util.HashFileInfo.hashArray"),
     )


### PR DESCRIPTION
Ref https://github.com/lucidsoftware/neo-sbt-scalafmt/issues/80

We discovered in the community build that 1.3.0-RC4 breaks the
lucidchart scalafmt plugins. We can unbreak binary compatibility by
adding alternative classes.