### PR TITLE
Fix FileHash equality

### DIFF
--- a/util-cache/src/main/scala/sbt/util/FileInfo.scala
+++ b/util-cache/src/main/scala/sbt/util/FileInfo.scala
@@ -41,7 +41,14 @@ private final case class FileHash(file: File, override val hash: List[Byte]) ext
   override val hashArray: Array[Byte] = hash.toArray
 }
 private final case class FileHashArrayRepr(file: File, override val hashArray: Array[Byte])
-    extends HashFileInfo
+    extends HashFileInfo {
+  override def hashCode(): Int = (file, java.util.Arrays.hashCode(hashArray)).hashCode()
+  override def equals(obj: Any): Boolean = obj match {
+    case that: FileHashArrayRepr =>
+      this.file == that.file && java.util.Arrays.equals(this.hashArray, that.hashArray)
+    case _ => false
+  }
+}
 @deprecated("Kept for plugin compat, but will be removed in sbt 2.0", "1.3.0")
 private final case class FileHashModified(
     file: File,


### PR DESCRIPTION
`FileHash` equality was broken in #208 (but then fixed again in #212). Here I make sure arrays are compared properly in `FileHashArrayRepr`, otherwise `FilesInfo.hash` may not work.

Was found in `scalajs-bundler` with `sbt-1.3.0-RC4`: it always re-invokes `npmUpdate`.