### PR TITLE
Interlace log lines with task progress

### DIFF
--- a/internal/util-logging/src/main/scala/sbt/internal/util/ConsoleAppender.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/ConsoleAppender.scala
@@ -523,12 +523,12 @@ class ConsoleAppender private[ConsoleAppender] (
   }
 
   private def write(msg: String): Unit = {
-    if (!useFormat || !ansiCodesSupported) {
-      out.println(EscHelpers.removeEscapeSequences(msg))
-    } else if (ConsoleAppender.showProgress) {
-      SuperShellLogger.writeMsg(out, msg)
+    val toWrite =
+      if (!useFormat || !ansiCodesSupported) EscHelpers.removeEscapeSequences(msg) else msg
+    if (ConsoleAppender.showProgress) {
+      SuperShellLogger.writeMsg(out, toWrite)
     } else {
-      out.println(msg)
+      out.println(toWrite)
     }
   }
 


### PR DESCRIPTION
With the current supershell implementation, the progress display
flickers when there is heavy console logging during task evaluation.
This is because the console appender clears out the task progress and it
isn't restored until the next periodic super shell report (which
runs every 100ms by default). To remove the flickering, I reworked the
implementation to interlace the log lines with progress reports. In
order to ensure that the log lines remained contiguous, I had to apply
padding at the bottom of the supershell region whenever the new report
contained fewer lines than the old report. The report shifts down as new
log lines are appended. This isn't optimal, but I think removing
the flickering while preserving contiguous log lines is worth it.