### PR TITLE
Fix supershell position bug

### DIFF
--- a/internal/util-logging/src/main/scala/sbt/internal/util/ConsoleAppender.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/ConsoleAppender.scala
@@ -333,10 +333,14 @@ private object SuperShellLogger {
       out.println(s"$DeleteLine$l")
       if (progress.length > 0) {
         val stripped = ascii.matcher(l).replaceAll("")
-        val isDebugLine =
-          l.startsWith("[debug]") || l.startsWith(s"${scala.Console.RESET}[debug]")
-        // As long as the line isn't a debug line, we can assume it was printed to
-        // the console and reduce the top padding.
+        // This is a hack to exclude debug lines from decreasing the padding count.
+        // The side effect is that when debug is on, they will unfortunately not reduce
+        // the padding even though they are printed to stdout. If a log line contains
+        // the string "debug", it also won't decrease the padding. It gets complicated
+        // comparing strings formatted with ansi codes, so we have to tolerate the hack
+        // for now. Without it, the supershell region can be incorrectly shrunken which
+        // causes stale tasks to persist at the bottom.
+        val isDebugLine = l.contains("debug")
         val pad = if (padding.get > 0 && !isDebugLine) padding.decrementAndGet else padding.get
         deleteConsoleLines(out, blankZone + pad)
         progress.foreach(out.println)


### PR DESCRIPTION
While dogfooding the latest sbt, I realized that sometimes debug lines
were still decreasing the padding of the supershell region. This would
cause stale tasks to persist at the bottom of the supershell area. I
relax the isDebugLine check to be safe. This means that sometimes the
supershell region will stay a bit larger than it needs to be with extra
blank lines, but that's better than having the stale tasks at the
bottom.