### PR TITLE
Load SuccessEventTag lazily

### DIFF
--- a/internal/util-logging/src/main/scala/sbt/internal/util/ManagedLogger.scala
+++ b/internal/util-logging/src/main/scala/sbt/internal/util/ManagedLogger.scala
@@ -25,7 +25,7 @@ class ManagedLogger(
     )
   }
 
-  private val SuccessEventTag = scala.reflect.runtime.universe.typeTag[SuccessEvent]
+  private lazy val SuccessEventTag = scala.reflect.runtime.universe.typeTag[SuccessEvent]
   // send special event for success since it's not a real log level
   override def success(message: => String): Unit = {
     infoEvent[SuccessEvent](SuccessEvent(message))(


### PR DESCRIPTION
It takes about a second to load scala.reflect.runtime.universe. If we
lazy load here, we can load scala.relect.runtime.universe in the
background to speed up the sbt start up time. See
0ebb7a5662f2bcc6599010f5a81ed0a540581fd8.